### PR TITLE
feat: add .agents/skills/ canonical source, agents-docs/, scripts, sy…

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,39 @@
+# .agents/skills/ - Canonical Skill Source
+
+This is the **single canonical location** for all skills in this repository.
+
+CLI-specific folders contain only symlinks pointing here:
+
+```
+.claude/skills/<name>      -> ../../.agents/skills/<name>
+.opencode/agent/<name>     -> ../../.agents/skills/<name>
+.gemini/skills/<name>      -> ../../.agents/skills/<name>
+```
+
+## Setup
+
+After cloning, run once to create all symlinks:
+
+```bash
+./scripts/setup-skills.sh
+```
+
+Validate symlinks are intact:
+
+```bash
+./scripts/validate-skills.sh
+```
+
+## Adding a New Skill
+
+1. Create `.agents/skills/<skill-name>/SKILL.md` (see `agents-docs/SKILLS.md`)
+2. Run `./scripts/setup-skills.sh` to create symlinks for all CLI tools
+3. The skill is now available in Claude Code, OpenCode, and Gemini CLI
+
+## Skills in This Repository
+
+<!-- TODO: List your skills here as they are added -->
+<!-- Example:
+- `agent-coordination/` - Multi-agent orchestration patterns
+- `shell-script-quality/` - Shell script best practices
+-->

--- a/.claude/skills/SYMLINK_README.md
+++ b/.claude/skills/SYMLINK_README.md
@@ -1,0 +1,16 @@
+# .claude/skills/ - Symlinks Only
+
+This folder contains **symlinks only**. Do not add real skill files here.
+
+All skills live canonically in `.agents/skills/`.
+Each entry here is a symlink created by `./scripts/setup-skills.sh`.
+
+```
+<skill-name>/  ->  ../../.agents/skills/<skill-name>/
+```
+
+To add a new skill:
+1. Create it in `.agents/skills/<skill-name>/`
+2. Run `./scripts/setup-skills.sh` to create symlinks in all CLI folders
+
+See `agents-docs/SKILLS.md` for authoring guidelines.

--- a/.gemini/skills/SYMLINK_README.md
+++ b/.gemini/skills/SYMLINK_README.md
@@ -1,0 +1,16 @@
+# .gemini/skills/ - Symlinks Only
+
+This folder contains **symlinks only**. Do not add real skill files here.
+
+All skills live canonically in `.agents/skills/`.
+Each entry here is a symlink created by `./scripts/setup-skills.sh`.
+
+```
+<skill-name>/  ->  ../../.agents/skills/<skill-name>/
+```
+
+To add a new skill:
+1. Create it in `.agents/skills/<skill-name>/`
+2. Run `./scripts/setup-skills.sh` to create symlinks in all CLI folders
+
+See `agents-docs/SKILLS.md` for authoring guidelines.

--- a/.opencode/agent/SYMLINK_README.md
+++ b/.opencode/agent/SYMLINK_README.md
@@ -1,0 +1,18 @@
+# .opencode/agent/ - Symlinks for Skills
+
+This folder contains **symlinks only** for skills. Do not add real skill files here.
+
+All skills live canonically in `.agents/skills/`.
+Each skill entry here is a symlink created by `./scripts/setup-skills.sh`.
+
+```
+<skill-name>/  ->  ../../.agents/skills/<skill-name>/
+```
+
+Note: Agent `.md` definition files (not skills) are real files in this folder.
+
+To add a new skill:
+1. Create it in `.agents/skills/<skill-name>/`
+2. Run `./scripts/setup-skills.sh` to create symlinks in all CLI folders
+
+See `agents-docs/SKILLS.md` for authoring guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,161 @@
 # AGENTS.md
 
-This file provides guidance to agents when working with code in this repository.
+> Single source of truth for all AI coding agents in this repository.
+> Supported by: Claude Code, Windsurf, Gemini CLI, Codex, Copilot, OpenCode, Devin, Amp, Zed, Warp, RooCode, Jules.
+> See the open spec: https://agents.md
 
-## File Size Constraint
-- **Max 500 LOC per file** - split files exceeding this limit into smaller, focused modules
-- Extract shared utilities, types, and components into separate files
+## Project Overview
+
+<!-- TODO: Replace with 2-3 sentences describing this project, its purpose, and primary tech stack. -->
+This is a generic template repository. Replace this section with your project overview.
+
+## Setup
+
+```bash
+# Install dependencies
+# TODO: pnpm install | cargo build | pip install -r requirements.txt
+
+# Start dev server / run project
+# TODO: pnpm dev | cargo run | python main.py
+
+# Create skill symlinks after cloning (single source: .agents/skills/)
+./scripts/setup-skills.sh
+
+# Install git pre-commit hook
+cp scripts/pre-commit-hook.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+## Run Tests
+
+```bash
+# Unit tests
+# TODO: cargo test --lib | pnpm test:unit | pytest tests/unit
+
+# Integration tests
+# TODO: cargo test --test '*' | pnpm test:integration | pytest tests/integration
+
+# Full quality gate (run before every commit)
+./scripts/quality_gate.sh
+```
+
+Always run the full quality gate before committing. Fix all errors before finishing a task.
+
+## Code Style
+
+- **Max 500 lines per source file** - split into focused sub-modules if exceeded
+- Conventional Commits: `feat:`, `fix:`, `docs:`, `ci:`, `test:`, `refactor:`
+- All public APIs must be documented
+- No hardcoded magic numbers - use named constants or config
+- Render architecture diagrams as fenced ```mermaid``` blocks, never raw ASCII art
+
+<!-- TODO: Uncomment the language block(s) relevant to your project -->
+
+<!--
+#### Rust
+- Edition 2021, stable toolchain; `cargo fmt` + `cargo clippy -- -D warnings` must pass
+- Errors via `thiserror`; propagation via `anyhow` or `?`
+- Async I/O via Tokio; CPU parallelism via Rayon
+- All fallible public APIs return `Result<T, Error>`
+- See agents-docs/RUST.md for patterns and anti-patterns
+-->
+
+<!--
+#### TypeScript / JavaScript
+- Strict mode; ESModules only; no implicit `any`
+- Functional patterns preferred; single quotes, no semicolons
+-->
+
+<!--
+#### Python
+- Python 3.10+, async/await; `ruff` + `black`; type hints on all public functions
+-->
+
+## Repository Structure
+
+```
+<project-root>/
+├── AGENTS.md              # This file - agent instructions (single source of truth)
+├── CLAUDE.md              # Claude Code-specific overrides only (@AGENTS.md)
+├── GEMINI.md              # Gemini CLI-specific overrides only (@AGENTS.md)
+├── agents-docs/           # Detailed reference docs (loaded on demand, not by default)
+│   ├── HARNESS.md         # MCP, skills, sub-agents, hooks overview
+│   ├── SKILLS.md          # Skill authoring and progressive disclosure
+│   ├── SUB-AGENTS.md      # Context isolation patterns
+│   ├── HOOKS.md           # Hook configuration and verification
+│   ├── CONTEXT.md         # Context engineering and back-pressure
+│   └── RUST.md            # Rust-specific patterns (remove if not Rust)
+├── .agents/
+│   └── skills/            # CANONICAL skill source - all agents read from here
+│       └── <skill-name>/
+│           ├── SKILL.md   # <= 250 lines
+│           ├── reference/ # Detailed docs linked from SKILL.md
+│           ├── scripts/   # Executable scripts
+│           └── assets/    # Templates, examples
+├── .claude/
+│   ├── agents/            # Claude Code sub-agent definitions
+│   ├── commands/          # Custom slash commands
+│   └── skills/            # Symlinks -> ../../.agents/skills/<name>
+├── .opencode/
+│   ├── agent/             # Symlinks -> ../../.agents/skills/<name>
+│   └── command/
+├── .gemini/
+│   └── skills/            # Symlinks -> ../../.agents/skills/<name>
+├── scripts/
+│   ├── setup-skills.sh    # Creates all symlinks (run on clone)
+│   ├── validate-skills.sh # Validates all symlinks are intact
+│   ├── quality_gate.sh    # Full pre-commit quality gate
+│   └── pre-commit-hook.sh # Git hook entry point
+├── README.md
+└── .github/workflows/
+```
+
+## Testing Instructions
+
+- Write or update tests for every code change, even if not explicitly requested
+- Tests must be deterministic - use seeded RNG where randomness is needed
+- Success is silent; only surface failures (context-efficient back-pressure)
+- See `agents-docs/CONTEXT.md` for back-pressure patterns
+
+## PR Instructions
+
+- Title format: `[type(scope)] short description`
+- Always run lint and tests before committing
+- Create a new branch per feature/fix - never commit directly to `main`
+- Keep PRs focused; one concern per PR
+
+## Security
+
+- Never commit secrets or API keys - use environment variables or `.env` (gitignored)
+- Never connect to untrusted MCP servers - tool descriptions inject into the system prompt
+- Report vulnerabilities via GitHub private advisories
+
+## Agent Guidance
+
+### Plan Before Executing
+For non-trivial tasks: produce a written plan first, pause, and wait for confirmation
+before writing code.
+
+### Skills: Single Source in .agents/skills/
+All skills live canonically in `.agents/skills/`. CLI-specific folders contain only
+symlinks pointing back to `.agents/skills/`. Run `./scripts/setup-skills.sh` after
+cloning to create all symlinks. See `agents-docs/SKILLS.md`.
+
+### Context Discipline
+- Delegate isolated research and analysis to sub-agents
+- Use `/clear` between unrelated tasks
+- Load skills only when needed, not upfront
+
+### Nested AGENTS.md
+For monorepos, place an additional `AGENTS.md` inside each sub-package.
+The agent reads the nearest file in the directory tree - closest one takes precedence.
+
+### Reference Docs
+
+| Topic | File |
+|---|---|
+| Harness engineering overview | `agents-docs/HARNESS.md` |
+| Skill authoring | `agents-docs/SKILLS.md` |
+| Sub-agent patterns | `agents-docs/SUB-AGENTS.md` |
+| Hooks | `agents-docs/HOOKS.md` |
+| Context / back-pressure | `agents-docs/CONTEXT.md` |
+| Rust patterns | `agents-docs/RUST.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,46 @@
 @AGENTS.md
+
+<!-- Claude Code-specific instructions only. Do not duplicate content from AGENTS.md. -->
+
+## Claude Code Features
+
+### Sub-Agents
+Sub-agent definitions live in `.claude/agents/`. Each is a Markdown file with YAML
+frontmatter (`name`, `description`, `tools`, `model`).
+
+Default agents in this template:
+- `agent-creator` - scaffold new sub-agent definitions
+- `goap-agent` - goal-oriented action planning for complex workflows
+- `loop-agent` - iterative refinement loops
+- `analysis-swarm` - parallel multi-perspective code analysis
+
+Delegate context-heavy research to sub-agents to keep the parent session focused.
+See `agents-docs/SUB-AGENTS.md`.
+
+### Skills
+Skills live canonically in `.agents/skills/`. The `.claude/skills/` folder contains
+only symlinks. Run `./scripts/setup-skills.sh` once after cloning.
+
+Skills use progressive disclosure - `SKILL.md` is injected only when the agent
+decides the skill is needed. Do not pre-load all skills at session start.
+See `agents-docs/SKILLS.md`.
+
+### Custom Commands
+Project slash commands live in `.claude/commands/`. Use them for repeatable workflows.
+
+### Hooks
+Verification hooks run automatically on agent stop events.
+- Exit `0` = silent success (nothing extra enters context)
+- Exit `2` = errors surfaced to agent, forcing remediation before finishing
+See `agents-docs/HOOKS.md`.
+
+### Headless / CI Mode
+```bash
+claude -p "your prompt" --output-format stream-json
+```
+
+### Context Management
+- Use `/clear` between unrelated tasks
+- Use `Glob`/`Grep` to find code instead of reading whole file trees
+- Prefer sub-agents for multi-step research tasks
+- See `agents-docs/CONTEXT.md`

--- a/agents-docs/CONTEXT.md
+++ b/agents-docs/CONTEXT.md
@@ -1,0 +1,55 @@
+# Context Engineering and Back-Pressure
+
+> Reference doc - not loaded by default.
+
+Context engineering = systematically managing what enters the context window
+to maximize reliability and minimize cost.
+
+## The Instruction Budget
+
+Every item (tool descriptions, instructions, file contents, messages) consumes budget.
+Performance degrades as context grows - longer is not better.
+
+## Back-Pressure Priority Order
+
+Implement from top down:
+
+1. **Typechecks / build** - fast, deterministic, catches structural errors instantly
+2. **Unit tests** - validates logic
+3. **Integration tests** - validates system behavior
+4. **Lint / format** - enforces style
+5. **Coverage reporting** - surface drops via hook
+6. **UI/browser testing** - Playwright, agent-browser
+
+**Critical:** All verification must be context-efficient.
+Swallow passing output - surface only failures.
+
+## Context Hygiene
+
+- `/clear` between unrelated tasks
+- `Glob`/`Grep` instead of reading whole files
+- Sub-agents for research (noise stays in their window)
+- Load skills progressively - not at session start
+- Prefer CLI tools over MCP servers for well-known services
+
+## Skills Architecture (Progressive Disclosure)
+
+```
+AGENTS.md (concise, universal)
+  +-- agents-docs/ (detailed reference, loaded on demand)
+       +-- Skills with SKILL.md (loaded when agent needs them)
+            +-- reference/ within each skill (read only what is needed)
+```
+
+All skills are canonical in `.agents/skills/`.
+CLI folders (`.claude/skills/`, `.opencode/agent/`, `.gemini/skills/`) contain
+only symlinks - run `./scripts/setup-skills.sh` to create them.
+
+## Anti-Patterns
+
+- Running the full test suite after every change
+- Reading large file trees into context
+- Installing many MCP servers just in case
+- One very long session for a multi-day project
+- Using larger context windows as a substitute for context isolation
+- Auto-generating AGENTS.md (hurts performance; always human-written)

--- a/agents-docs/HARNESS.md
+++ b/agents-docs/HARNESS.md
@@ -1,0 +1,44 @@
+# Harness Engineering
+
+> Reference doc - not loaded by default. Link from AGENTS.md or a skill as needed.
+
+`coding agent = AI model(s) + harness`
+
+The harness is everything around the model: AGENTS.md, MCP servers, skills, sub-agents,
+hooks, and back-pressure mechanisms. Harness engineering is the practice of tuning these
+surfaces to improve output quality and reliability.
+
+## Core Principle: Iterate on Failure
+
+Do not design the ideal harness upfront. Add configuration **only when the agent actually
+fails**. When a failure occurs, engineer a solution so it cannot happen the same way again.
+Throw away what does not help - more config is not always better.
+
+## AGENTS.md Guidelines
+
+- Keep under ~100 lines; human-written (never auto-generated - LLM-generated files hurt quality)
+- Concise and universally applicable - every instruction costs tokens
+- Use progressive disclosure: detailed docs in `agents-docs/`, not the root file
+
+## Skills (Single Canonical Source)
+
+All skills live in `.agents/skills/`. CLI-specific folders (`.claude/skills/`,
+`.opencode/agent/`, `.gemini/skills/`) contain only symlinks.
+Run `./scripts/setup-skills.sh` to create them. See `agents-docs/SKILLS.md`.
+
+## MCP Servers
+
+- Only connect servers you actively use and trust
+- Tool descriptions inject into the system prompt - each one consumes instruction budget
+- Prefer well-known CLIs (GitHub, Docker, databases) over MCP
+- Write thin CLI wrappers with concise output rather than verbose MCP responses
+- Never connect to untrusted MCP servers - they are a prompt injection vector
+
+## Further Reading
+
+| Topic | File |
+|---|---|
+| Skills | `agents-docs/SKILLS.md` |
+| Sub-Agents | `agents-docs/SUB-AGENTS.md` |
+| Hooks | `agents-docs/HOOKS.md` |
+| Back-Pressure | `agents-docs/CONTEXT.md` |

--- a/agents-docs/HOOKS.md
+++ b/agents-docs/HOOKS.md
@@ -1,0 +1,59 @@
+# Hooks - Verification and Automation
+
+> Reference doc - not loaded by default.
+
+Hooks are agent lifecycle commands that enforce deterministic control flow.
+Supported by: Claude Code, OpenCode.
+
+## Golden Rules
+
+- **Success = silent** (exit 0, nothing enters context)
+- **Failure = explicit** (exit 2, errors surfaced to agent for remediation)
+- **Context-efficient** - swallow passing output; stream only failures
+
+## Common Use Cases
+
+| Hook type | Purpose |
+|---|---|
+| Stop hook | Typecheck + lint + format after every agent action |
+| Pre-tool hook | Approve/deny specific tool calls (e.g. block destructive ops) |
+| Post-tool hook | Send notification, create PR, set up preview env |
+
+## Stop Hook Template
+
+```bash
+#!/bin/bash
+cd "$CLAUDE_PROJECT_DIR"
+
+OUTPUT=$(your-lint-cmd && your-typecheck-cmd 2>&1)
+
+if [ $? -ne 0 ]; then
+  echo "$OUTPUT" >&2
+  exit 2
+fi
+# success: exit 0 silently
+```
+
+## Validate Skills Hook
+
+Add to your stop hook to always verify symlinks are intact:
+
+```bash
+./scripts/validate-skills.sh || exit 2
+```
+
+## What Did NOT Work (lessons)
+
+- Running the full test suite on every stop (floods context; use targeted subsets)
+- Hooks that produce verbose output on success (pollutes context window)
+- Micro-optimizing which sub-agents can access which tools (tool thrash)
+
+## Back-Pressure Priority (implement top-down)
+
+1. Typechecks / build - fast, deterministic
+2. Unit tests - validates logic
+3. Integration tests - validates system behavior
+4. Lint / format - enforces style
+5. Coverage reporting - surface drops via hook
+
+See `agents-docs/CONTEXT.md` for full back-pressure patterns.

--- a/agents-docs/RUST.md
+++ b/agents-docs/RUST.md
@@ -1,0 +1,55 @@
+# Rust Development Patterns
+
+> Reference doc - not loaded by default.
+> Remove this file if your project is not Rust.
+
+## Toolchain
+
+- Stable toolchain, edition 2021
+- `cargo fmt` + `cargo clippy -- -D warnings` must pass before every commit
+- All fallible public APIs return `Result<T, Error>`
+- Errors defined via `thiserror`; propagation via `anyhow` or `?`
+
+## Async and Concurrency
+
+- Async I/O via Tokio; CPU parallelism via Rayon
+- Do NOT share a single Connection across async tasks via `RwLock`
+  Use per-operation `connect()` instead - cheap and avoids Send/Sync issues
+- Gate WASM threading: `#[cfg(not(target_arch = "wasm32"))]`
+
+## Numeric Safety
+
+- `f32::total_cmp()` for float sorting - **never** `partial_cmp().unwrap()` (panics on NaN)
+- Seeded RNG (`StdRng::seed_from_u64(42)`) in tests for determinism
+
+## Memory and Performance
+
+- Dense matrices for large N are infeasible - use CSR sparse format
+- `Vec<Vec<(usize, f32)>>` has allocator overhead; prefer contiguous CSR buffers
+- Memory locality often dominates arithmetic throughput for large sparse structures
+- No connection pooling for local SQLite - no benefit, adds overhead
+
+## Code Organization
+
+- Max 500 lines per source file - split into focused sub-modules if exceeded
+- No hardcoded magic numbers - named constants or config only
+- Never create unused code - verify at least one usage site before adding APIs
+- Architecture diagrams in ```mermaid``` blocks, never raw ASCII art
+
+## CI Validation
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+cargo build --release
+```
+
+## WASM
+
+```bash
+cargo build --target wasm32-unknown-unknown
+wasm-pack build --target web
+```
+
+Gate all threading/I/O with `#[cfg(not(target_arch = "wasm32"))]`.

--- a/agents-docs/SKILLS.md
+++ b/agents-docs/SKILLS.md
@@ -1,0 +1,76 @@
+# Skills - Authoring Guide
+
+> Reference doc - not loaded by default.
+
+## Canonical Location
+
+All skills live in `.agents/skills/` (the canonical source).
+CLI-specific folders contain only symlinks:
+
+```
+.agents/skills/<name>/          <- CANONICAL
+.claude/skills/<name>           -> symlink -> ../../.agents/skills/<name>
+.opencode/agent/<name>          -> symlink -> ../../.agents/skills/<name>
+.gemini/skills/<name>           -> symlink -> ../../.agents/skills/<name>
+```
+
+Run `./scripts/setup-skills.sh` after cloning to create all symlinks.
+Run `./scripts/validate-skills.sh` to verify integrity.
+
+## Why .agents/ as Canonical?
+
+`.claude/` is Claude Code-specific. `.agents/` is tool-agnostic - it works when you
+add Gemini CLI, OpenCode, Codex, or any future harness without moving files.
+
+## Progressive Disclosure
+
+Skills prevent instruction budget exhaustion: a skill's `SKILL.md` is loaded only
+when the agent decides it is needed. Do not pre-load all skills at session start.
+
+## Directory Structure
+
+```
+.agents/skills/
++-- skill-name/
+    +-- SKILL.md          # Primary instructions (<= 250 lines)
+    +-- reference/        # Detailed docs linked from SKILL.md
+    +-- scripts/          # Executable scripts the agent can run directly
+    +-- assets/           # Templates, examples
+```
+
+## SKILL.md Template
+
+```markdown
+# Skill Name
+
+Brief description.
+
+## When to Use
+Activate when: [specific triggers]
+
+## Instructions
+[Concise, universally applicable instructions]
+
+## Reference Files
+- `reference/guide.md` - [when to read]
+- `scripts/run.sh` - [what it does]
+
+## Examples
+[Concrete usage]
+```
+
+## Rules
+
+- `SKILL.md` <= 250 lines - detailed content in `reference/`
+- Include executable scripts so the agent can validate directly
+- Cite sources as `filepath:line` so the parent agent can find context
+- Do not duplicate content already in `AGENTS.md`
+- Never install skills from untrusted registries - read them first
+
+## Agent vs Skill
+
+| Use a Skill | Use a Sub-Agent |
+|---|---|
+| Reusable reference knowledge | Complex multi-step execution |
+| Main agent executes with guidance | Needs isolated context window |
+| No context isolation needed | Different tool access than parent |

--- a/agents-docs/SUB-AGENTS.md
+++ b/agents-docs/SUB-AGENTS.md
@@ -1,0 +1,53 @@
+# Sub-Agents - Context Control Patterns
+
+> Reference doc - not loaded by default.
+
+Sub-agents are **context firewalls**. The parent agent sees only what it wrote and the
+final result - none of the intermediate tool calls, file reads, or searches accumulate
+in the parent's context window (context rot).
+
+## When to Use
+
+Good candidates (clear question, many intermediate steps):
+- Finding specific implementations in a large codebase
+- Tracing data flow across service boundaries
+- Codebase pattern analysis
+- Web / documentation research
+- Security review of completed work
+
+## Sub-Agent System Prompt Rules
+
+Always specify:
+1. **Role** - what it does AND does not do
+2. **Return format** - condensed answer with `filepath:line` citations
+3. **Tool access** - only what is needed for the discrete task
+
+## Cost Control
+
+- Parent session (orchestration): expensive model (Opus)
+- Sub-agents (discrete tasks): cheaper model (Sonnet / Haiku)
+
+## Claude Code Format (.claude/agents/<name>.md)
+
+```yaml
+---
+name: agent-name
+description: What this agent does. Invoke when [specific scenarios].
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+[Agent system prompt here]
+```
+
+## Naming Convention
+
+- Lowercase, hyphens only, max 64 chars
+- Examples: `code-reviewer`, `test-runner`, `research-agent`
+
+## Anti-Patterns
+
+- One huge orchestration agent doing everything (fills context fast)
+- Sharing context indiscriminately between agents
+- Using expensive models for all sub-agents
+- Micro-optimizing tool access (tool thrash = worse results)

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Git pre-commit hook.
+# Install: cp scripts/pre-commit-hook.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+./scripts/quality_gate.sh
+
+echo "Pre-commit checks passed."

--- a/scripts/quality_gate.sh
+++ b/scripts/quality_gate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Full quality gate. Runs all checks. Exit 2 = surface errors to agent.
+# TODO: Uncomment and adapt the block(s) for your tech stack.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+cd "$REPO_ROOT"
+
+FAILED=0
+
+# --- Always: validate skill symlinks ---
+if ! ./scripts/validate-skills.sh; then
+  FAILED=1
+fi
+
+# --- Rust ---
+# if [ -f Cargo.toml ]; then
+#   OUTPUT=$(cargo fmt --check 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+#   OUTPUT=$(cargo clippy -- -D warnings 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+#   OUTPUT=$(cargo test 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+# fi
+
+# --- TypeScript / Node ---
+# if [ -f package.json ]; then
+#   OUTPUT=$(pnpm lint 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+#   OUTPUT=$(pnpm typecheck 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+#   OUTPUT=$(pnpm test 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+# fi
+
+# --- Python ---
+# if [ -f requirements.txt ] || [ -f pyproject.toml ]; then
+#   OUTPUT=$(ruff check . 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+#   OUTPUT=$(black --check . 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+#   OUTPUT=$(pytest tests/ -q 2>&1) || { echo "$OUTPUT" >&2; FAILED=1; }
+# fi
+
+if [ $FAILED -ne 0 ]; then
+  exit 2
+fi
+
+echo "Quality gate passed."

--- a/scripts/setup-skills.sh
+++ b/scripts/setup-skills.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Creates symlinks from CLI-specific folders -> .agents/skills/ (canonical source)
+# Run once after cloning: ./scripts/setup-skills.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+SKILLS_SRC="$REPO_ROOT/.agents/skills"
+
+# CLI folders that should contain symlinks to canonical skills
+CLI_SKILL_DIRS=(
+  ".claude/skills"
+  ".opencode/agent"
+  ".gemini/skills"
+)
+
+if [ ! -d "$SKILLS_SRC" ]; then
+  echo "No skills found at .agents/skills/ - nothing to symlink."
+  exit 0
+fi
+
+echo "Setting up skill symlinks from .agents/skills/..."
+
+for cli_dir in "${CLI_SKILL_DIRS[@]}"; do
+  target_dir="$REPO_ROOT/$cli_dir"
+  mkdir -p "$target_dir"
+
+  for skill_path in "$SKILLS_SRC"/*/; do
+    [ -d "$skill_path" ] || continue
+    skill_name="$(basename "$skill_path")"
+    link="$target_dir/$skill_name"
+    # Relative path from CLI dir back to .agents/skills
+    rel="$(realpath --relative-to="$target_dir" "$skill_path")"
+
+    if [ -L "$link" ]; then
+      echo "  skip (exists): $cli_dir/$skill_name"
+    elif [ -d "$link" ]; then
+      echo "  WARN: real dir exists at $cli_dir/$skill_name - skipping"
+    else
+      ln -s "$rel" "$link"
+      echo "  linked: $cli_dir/$skill_name -> $rel"
+    fi
+  done
+done
+
+echo ""
+echo "Skill symlinks created. Run scripts/validate-skills.sh to verify."

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Validates all CLI skill symlinks point to existing .agents/skills/ directories.
+# Used in pre-commit hook and CI. Exit 2 on failure (surfaced to agent).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+SKILLS_SRC="$REPO_ROOT/.agents/skills"
+
+CLI_SKILL_DIRS=(
+  ".claude/skills"
+  ".opencode/agent"
+  ".gemini/skills"
+)
+
+FAILED=0
+
+# If no skills exist, nothing to validate
+if [ ! -d "$SKILLS_SRC" ] || [ -z "$(ls -A "$SKILLS_SRC" 2>/dev/null)" ]; then
+  echo "No skills in .agents/skills/ - nothing to validate."
+  exit 0
+fi
+
+for skill_path in "$SKILLS_SRC"/*/; do
+  [ -d "$skill_path" ] || continue
+  skill_name="$(basename "$skill_path")"
+
+  for cli_dir in "${CLI_SKILL_DIRS[@]}"; do
+    link="$REPO_ROOT/$cli_dir/$skill_name"
+    if [ ! -L "$link" ]; then
+      echo "MISSING symlink: $cli_dir/$skill_name" >&2
+      FAILED=1
+    elif [ ! -d "$link" ]; then
+      echo "BROKEN symlink: $cli_dir/$skill_name -> $(readlink "$link")" >&2
+      FAILED=1
+    fi
+  done
+done
+
+if [ $FAILED -ne 0 ]; then
+  echo "" >&2
+  echo "Run: ./scripts/setup-skills.sh to fix missing symlinks." >&2
+  exit 2
+fi
+
+echo "All skill symlinks valid."


### PR DESCRIPTION
…mlink architecture


- Rewrite AGENTS.md: generic agents.md spec, setup/test/style/PR/security/guidance
- Update CLAUDE.md: @AGENTS.md + Claude Code-only features
- Add agents-docs/: HARNESS.md, SKILLS.md, SUB-AGENTS.md, HOOKS.md, CONTEXT.md, RUST.md
- Add .agents/skills/README.md: canonical skill source index
- Add scripts/: setup-skills.sh, validate-skills.sh, quality_gate.sh, pre-commit-hook.sh
- Add SYMLINK_README.md to .claude/skills/, .opencode/agent/, .gemini/skills/

Skills live canonically in .agents/skills/; CLI folders contain symlinks only. Run ./scripts/setup-skills.sh after cloning to create symlinks. Existing skills in .claude/skills/ need git mv to .agents/skills/ (follow-up).