### PR TITLE
feat: add do-web-doc-resolver skill with intelligent cascade

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -43,5 +43,6 @@ Validate symlinks are intact:
 | [`shell-script-quality/`](shell-script-quality/) | Shell script linting (ShellCheck) and testing (BATS) |
 | [`skill-creator/`](skill-creator/) | Create new skills with proper structure and best practices |
 | [`task-decomposition/`](task-decomposition/) | Break complex tasks into manageable steps |
+| [`do-web-doc-resolver/`](do-web-doc-resolver/) | Intelligent web doc resolver with Python/Rust CLI, semantic cache, and multi-provider cascade |
 | [`web-doc-resolver/`](web-doc-resolver/) | Resolve and fetch web documentation with cascade fallback |
 | [`web-search-researcher/`](web-search-researcher/) | Research topics using web search with systematic methodology |

--- a/.agents/skills/do-web-doc-resolver/SKILL.md
+++ b/.agents/skills/do-web-doc-resolver/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: do-web-doc-resolver
+description: Resolve queries or URLs into compact, LLM-ready markdown using an intelligent, low-cost cascade. Prioritizes free sources (Exa MCP, llms.txt, DuckDuckGo), uses paid APIs only when necessary. Use when fetching documentation, resolving web URLs, or building context from web sources.
+license: MIT
+metadata:
+  source: https://github.com/d-oit/do-web-doc-resolver
+  version: "0.4.0"
+---
+
+# Web Documentation Resolver
+
+Resolve queries or URLs into compact, LLM-ready markdown using a progressive, free-first cascade.
+
+## When to Use
+
+Activate this skill when you need to:
+- Fetch and parse documentation from a URL
+- Search for technical information across the web
+- Build context from web sources for AI agents
+- Extract clean markdown from websites
+- Query for technical documentation, APIs, or code examples
+
+## Quick Start
+
+```bash
+# Python CLI
+python scripts/resolve.py "https://docs.rust-lang.org/book/"
+python scripts/resolve.py "Rust async programming best practices"
+
+# Rust CLI (faster)
+do-wdr resolve "https://example.com"
+do-wdr resolve "machine learning tutorials" --profile free
+```
+
+## Cascade Resolution Strategy
+
+### For URL Inputs
+
+1. **Semantic Cache** — Instant retrieval for known URLs
+2. **llms.txt** — Check for structured docs at `{origin}/llms.txt` (FREE)
+3. **Jina Reader** — `https://r.jina.ai/{url}` (FREE, 20 RPM)
+4. **Direct HTTP Fetch** — Basic HTML-to-text extraction (FREE)
+5. **Firecrawl** — Deep extraction with JS rendering (paid)
+6. **Mistral Browser** — AI-powered fallback (paid)
+7. **DuckDuckGo** — Search fallback (FREE)
+
+### For Query Inputs
+
+1. **Semantic Cache** — Multi-layer cache (URL, Query, Provider)
+2. **Exa MCP** — FREE search via Model Context Protocol (no API key!)
+3. **Exa SDK** — Token-efficient highlights (paid, low-cost)
+4. **Tavily** — Comprehensive search (paid)
+5. **Serper** — Google search via Serper API (2500 free credits)
+6. **DuckDuckGo** — Free search, always available (FREE)
+7. **Mistral Web Search** — AI-powered fallback (paid)
+
+## Execution Profiles
+
+| Profile | Max Attempts | Max Paid | Max Latency | Quality |
+|---------|-------------|----------|-------------|---------|
+| `free` | 3 | 0 | 6s | 0.70 |
+| `fast` | 2 | 1 | 4s | 0.60 |
+| `balanced` | 4-6 | 1-2 | 9-12s | 0.65 |
+| `quality` | 6-10 | 3-5 | 15-20s | 0.55 |
+
+## Key Features
+
+- **Zero-key operation**: Works with no API keys using free sources
+- **Circuit breakers**: Per-provider failure tracking with 5-minute cooldowns
+- **Routing memory**: Per-domain provider success rate learning
+- **Quality scoring**: Content scored 0.0-1.0 based on signals
+- **Content compaction**: Boilerplate removal and deduplication
+- **AI synthesis**: Cohesive answers from multiple providers
+
+## Configuration
+
+All API keys are optional. The resolver works without any keys.
+
+```bash
+# Provider keys (all optional)
+export EXA_API_KEY="your_key"
+export TAVILY_API_KEY="your_key"
+export SERPER_API_KEY="your_key"
+export FIRECRAWL_API_KEY="your_key"
+export MISTRAL_API_KEY="your_key"
+
+# Resolver settings
+export WEB_RESOLVER_MAX_CHARS=8000
+export WEB_RESOLVER_MIN_CHARS=200
+export WEB_RESOLVER_TIMEOUT=30
+```
+
+## Output Format
+
+```python
+{
+    "url": "https://example.com/docs",
+    "content": "# Documentation\n\n...",
+    "source": "exa_mcp",
+    "score": 0.87,
+    "metrics": {
+        "latency_ms": 1234,
+        "providers_attempted": ["exa_mcp"],
+        "cache_hit": false
+    }
+}
+```
+
+## Error Handling
+
+| Error Type | Detection | Behavior |
+|------------|-----------|----------|
+| rate_limit | 429 | Set cooldown, skip provider |
+| auth_error | 401, 403 | Log error, skip provider |
+| quota_exhausted | 402 | Log warning, skip provider |
+| network_error | timeout | Log error, skip provider |
+| not_found | 404 | Log error, skip provider |
+
+## References
+
+| Topic | File |
+|-------|------|
+| Cascade decision trees | `reference/cascade.md` |
+| Provider details | `reference/providers.md` |
+| Configuration | `reference/configuration.md` |

--- a/.agents/skills/do-web-doc-resolver/evals/evals.json
+++ b/.agents/skills/do-web-doc-resolver/evals/evals.json
@@ -1,0 +1,93 @@
+{
+  "skill_name": "do-web-doc-resolver",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need to fetch the documentation for the Rust Tokio library. What's the best way to do this?",
+      "expected_output": "The agent recommends using the web-doc-resolver skill with URL resolution cascade: first check for llms.txt at docs.rs, then Jina Reader (free), then direct fetch. Mentions that Exa MCP is free for query-based lookups.",
+      "files": [],
+      "assertions": [
+        "The agent identifies this as a URL resolution task",
+        "The agent recommends the free-first cascade approach",
+        "The agent mentions llms.txt or Jina Reader as free options"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I want to search for best practices on Python async programming, but I don't have any API keys configured. Can this still work?",
+      "expected_output": "The agent confirms that the resolver works without API keys using free providers: Exa MCP (free, no key), DuckDuckGo (free), and llms.txt probes. Mentions the 'free' execution profile.",
+      "files": [],
+      "assertions": [
+        "The agent confirms zero-key operation is supported",
+        "The agent mentions Exa MCP or DuckDuckGo as free options",
+        "The agent mentions the 'free' execution profile or free-first approach"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "My resolver keeps hitting rate limits on Exa. How does the circuit breaker handle this?",
+      "expected_output": "The agent explains the circuit breaker pattern: 3 consecutive failures trigger a 5-minute cooldown, provider is skipped until cooldown expires, successful call resets the failure count. Mentions automatic fallback to next provider.",
+      "files": [],
+      "assertions": [
+        "The agent explains the circuit breaker mechanism",
+        "The agent mentions the cooldown period (5 minutes/300 seconds)",
+        "The agent explains automatic fallback behavior"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I need high-quality research results and don't mind paying for API calls. Which profile should I use?",
+      "expected_output": "The agent recommends the 'quality' execution profile which allows 3-5 paid providers, 6-10 attempts, and has a lower quality threshold (0.55) for accepting more comprehensive results. Mentions Tavily, Exa SDK, and Mistral as paid options.",
+      "files": [],
+      "assertions": [
+        "The agent recommends the 'quality' profile",
+        "The agent mentions higher provider attempts and paid provider allowance",
+        "The agent lists available paid providers"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "What's the difference between the URL resolution cascade and the query resolution cascade?",
+      "expected_output": "The agent explains that URL cascade checks for structured content (llms.txt, Jina Reader) and document types (PDF, DOCX), while query cascade uses search providers (Exa MCP, DuckDuckGo). Both use free-first approach with paid fallbacks.",
+      "files": [],
+      "assertions": [
+        "The agent distinguishes between URL and query input types",
+        "The agent mentions llms.txt/Jina for URLs",
+        "The agent mentions search providers for queries"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "How does the routing memory feature work?",
+      "expected_output": "The agent explains that routing memory tracks per-domain provider performance (success rate, latency, quality scores) and uses this data to rank providers for future requests to the same domain.",
+      "files": [],
+      "assertions": [
+        "The agent explains per-domain tracking",
+        "The agent mentions success rate, latency, or quality metrics",
+        "The agent explains how this improves future requests"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "I want to resolve documentation but limit the output to 5000 characters. How do I configure this?",
+      "expected_output": "The agent mentions setting WEB_RESOLVER_MAX_CHARS=5000 environment variable or using --max-chars 5000 in the CLI. Explains content compaction removes boilerplate.",
+      "files": [],
+      "assertions": [
+        "The agent mentions the max_chars configuration option",
+        "The agent provides the environment variable or CLI flag",
+        "The agent mentions content compaction or boilerplate removal"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "What providers are available and which ones are free?",
+      "expected_output": "The agent lists providers organized by type (URL vs query) and marks free ones: Exa MCP, DuckDuckGo, llms.txt, Jina Reader, Direct Fetch are free. Exa SDK, Tavily, Serper, Firecrawl, Mistral are paid.",
+      "files": [],
+      "assertions": [
+        "The agent lists available providers",
+        "The agent correctly identifies free vs paid providers",
+        "The agent organizes by URL or query type"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/do-web-doc-resolver/reference/cascade.md
+++ b/.agents/skills/do-web-doc-resolver/reference/cascade.md
@@ -1,0 +1,127 @@
+# Provider Cascade Reference
+
+## Overview
+
+The resolver auto-detects input type (URL vs query) and runs a free-first cascade optimized for cost and quality.
+
+## Query Resolution Cascade
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Query Resolution Flow                        │
+├─────────────────────────────────────────────────────────────────┤
+│  1. Cache Check (24h TTL)                                       │
+│     └─→ Hit: Return cached result                               │
+│                                                                  │
+│  2. Exa MCP (FREE, no API key)                                  │
+│     └─→ Success: Return if quality ≥ 0.65                       │
+│     └─→ Fail: Continue to next provider                         │
+│                                                                  │
+│  3. Exa SDK (paid, EXA_API_KEY)                                 │
+│     └─→ Requires API key + budget allows paid                   │
+│     └─→ Success: Return if quality ≥ 0.65                       │
+│                                                                  │
+│  4. Tavily (paid, TAVILY_API_KEY)                               │
+│     └─→ Requires API key + budget allows paid                   │
+│                                                                  │
+│  5. Serper (paid, SERPER_API_KEY)                               │
+│     └─→ Requires API key + budget allows paid                   │
+│                                                                  │
+│  6. DuckDuckGo (FREE, no API key)                               │
+│     └─→ Always available fallback                               │
+│                                                                  │
+│  7. Mistral Web Search (paid, MISTRAL_API_KEY)                  │
+│     └─→ Last resort AI-powered search                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## URL Resolution Cascade
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      URL Resolution Flow                         │
+├─────────────────────────────────────────────────────────────────┤
+│  1. Cache Check (24h TTL)                                       │
+│     └─→ Hit: Return cached result                               │
+│                                                                  │
+│  2. Special File Type Detection                                 │
+│     ├─→ .pdf, .docx, .pptx → Docling                            │
+│     └─→ .png, .jpg, .jpeg → OCR (Tesseract)                     │
+│                                                                  │
+│  3. llms.txt Probe (FREE)                                       │
+│     └─→ Check {origin}/llms.txt for structured docs             │
+│     └─→ Success: Return immediately (high quality signal)       │
+│                                                                  │
+│  4. Jina Reader (FREE)                                          │
+│     └─→ https://r.jina.ai/{url}                                 │
+│     └─→ Good for most static content                            │
+│                                                                  │
+│  5. Firecrawl (paid, FIRECRAWL_API_KEY)                         │
+│     └─→ Deep extraction with JS rendering                       │
+│     └─→ Requires API key + budget allows paid                   │
+│                                                                  │
+│  6. Direct HTTP Fetch (FREE)                                    │
+│     └─→ Simple GET + HTML-to-text extraction                    │
+│     └─→ Strips scripts, styles, normalizes whitespace           │
+│                                                                  │
+│  7. Mistral Browser (paid, MISTRAL_API_KEY)                     │
+│     └─→ AI-powered browser agent for complex pages              │
+│                                                                  │
+│  8. DuckDuckGo Fallback (FREE)                                  │
+│     └─→ Search for the URL as a query                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Hedging Strategy
+
+The resolver uses adaptive hedging to minimize latency:
+
+1. **P75 Latency Threshold**: If a provider hasn't responded within its learned P75 latency, the next provider is started in parallel.
+
+2. **Routing Memory**: Per-domain provider performance is tracked:
+   - Success rate
+   - Average latency
+   - Average quality score
+
+3. **Provider Ranking**: Providers are ranked by:
+   - Success rate (higher is better)
+   - Quality score (higher is better)
+   - Latency (lower is better)
+
+## Skip Providers
+
+Use `--skip` to exclude specific providers:
+
+```bash
+# Skip Exa MCP and Exa SDK
+python scripts/resolve.py "query" --skip exa_mcp --skip exa
+
+# Skip all paid providers (free profile)
+python scripts/resolve.py "query" --profile free
+```
+
+## Quality Thresholds
+
+Content must meet minimum quality to be accepted:
+
+| Profile | Quality Threshold | Max Attempts | Max Paid |
+|---------|-------------------|--------------|----------|
+| `free` | 0.70 | 3 | 0 |
+| `fast` | 0.60 | 2 | 1 |
+| `balanced` | 0.65 | 6 | 2 |
+| `quality` | 0.55 | 10 | 5 |
+
+## Circuit Breaker
+
+Providers are temporarily disabled after repeated failures:
+
+- **Failure threshold**: 3 consecutive failures
+- **Cooldown period**: 300 seconds (5 minutes)
+- **Reset**: Successful call resets failure count
+
+## Negative Cache
+
+Thin or low-quality results are cached to avoid re-probing:
+
+- **TTL**: 1800 seconds (30 minutes)
+- **Reasons**: `thin_content`, `error`, `timeout`

--- a/.agents/skills/do-web-doc-resolver/reference/configuration.md
+++ b/.agents/skills/do-web-doc-resolver/reference/configuration.md
@@ -1,0 +1,125 @@
+# Configuration Reference
+
+## Environment Variables
+
+### Provider API Keys (All Optional)
+
+| Variable | Provider | Notes |
+|----------|----------|-------|
+| `EXA_API_KEY` | Exa SDK | Optional - Exa MCP runs first (free) |
+| `TAVILY_API_KEY` | Tavily | Optional - comprehensive search |
+| `SERPER_API_KEY` | Serper | Optional - 2500 free credits |
+| `FIRECRAWL_API_KEY` | Firecrawl | Optional - deep extraction |
+| `MISTRAL_API_KEY` | Mistral | Optional - AI-powered fallback |
+
+### Resolver Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WEB_RESOLVER_MAX_CHARS` | 8000 | Maximum characters in output |
+| `WEB_RESOLVER_MIN_CHARS` | 200 | Minimum characters for valid result |
+| `WEB_RESOLVER_TIMEOUT` | 30 | Request timeout in seconds |
+| `WEB_RESOLVER_CACHE_TTL` | 86400 | Cache TTL in seconds (24h) |
+| `WEB_RESOLVER_PROFILE` | balanced | Default execution profile |
+
+### Setting API Keys
+
+```bash
+# Linux/macOS
+export EXA_API_KEY="your_key"
+export TAVILY_API_KEY="your_key"
+export SERPER_API_KEY="your_key"
+export FIRECRAWL_API_KEY="your_key"
+export MISTRAL_API_KEY="your_key"
+
+# Windows (PowerShell)
+$env:EXA_API_KEY="your_key"
+$env:TAVILY_API_KEY="your_key"
+```
+
+## Rust CLI Configuration
+
+The Rust CLI supports `config.toml` and `DO_WDR_*` environment variables:
+
+```toml
+# config.toml
+[providers.exa]
+api_key = "your_key"
+enabled = true
+
+[providers.tavily]
+api_key = "your_key"
+enabled = true
+
+[resolver]
+profile = "balanced"
+max_chars = 8000
+timeout_seconds = 30
+```
+
+### Rust CLI Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DO_WDR_EXA_API_KEY` | Exa API key |
+| `DO_WDR_TAVILY_API_KEY` | Tavily API key |
+| `DO_WDR_SERPER_API_KEY` | Serper API key |
+| `DO_WDR_FIRECRAWL_API_KEY` | Firecrawl API key |
+| `DO_WDR_MISTRAL_API_KEY` | Mistral API key |
+| `DO_WDR_PROFILE` | Default profile |
+| `DO_WDR_MAX_CHARS` | Max output characters |
+
+## Execution Profiles
+
+### Free Profile
+
+- Max 3 provider attempts
+- No paid providers
+- Quality threshold: 0.70
+- Best for: Development, testing
+
+### Fast Profile
+
+- Max 2 provider attempts
+- 1 paid provider allowed
+- Quality threshold: 0.60
+- Best for: Quick lookups
+
+### Balanced Profile (Default)
+
+- 4-6 provider attempts
+- 1-2 paid providers allowed
+- Quality threshold: 0.65
+- Best for: General use
+
+### Quality Profile
+
+- 6-10 provider attempts
+- 3-5 paid providers allowed
+- Quality threshold: 0.55
+- Best for: Research, comprehensive results
+
+## Cache Configuration
+
+### Semantic Cache
+
+- **Backend**: Turso/libsql (feature-gated)
+- **TTL**: 24 hours (configurable)
+- **Layers**: URL cache, Query cache, Provider cache
+
+### Negative Cache
+
+- **TTL**: 30 minutes
+- **Reasons**: `thin_content`, `error`, `timeout`
+- **Purpose**: Avoid re-probing known-failing providers
+
+## Quality Scoring
+
+Content is scored on a 0.0-1.0 scale:
+
+| Signal | Penalty |
+|--------|---------|
+| Too short (< 500 chars) | -0.35 |
+| Missing links | -0.15 |
+| Duplicate-heavy | -0.25 |
+| Noisy content | -0.20 |

--- a/.agents/skills/do-web-doc-resolver/reference/providers.md
+++ b/.agents/skills/do-web-doc-resolver/reference/providers.md
@@ -1,0 +1,97 @@
+# Provider Reference
+
+## Available Providers
+
+### Query Providers
+
+| Provider | Free | API Key Required | Description |
+|----------|------|------------------|-------------|
+| `exa_mcp` | Yes | No | Exa MCP via Model Context Protocol |
+| `exa` | No | EXA_API_KEY | Exa SDK with highlights |
+| `tavily` | No | TAVILY_API_KEY | Comprehensive web search |
+| `serper` | No | SERPER_API_KEY | Google search (2500 free credits) |
+| `duckduckgo` | Yes | No | DuckDuckGo search |
+| `mistral_websearch` | No | MISTRAL_API_KEY | AI-powered web search |
+
+### URL Providers
+
+| Provider | Free | API Key Required | Description |
+|----------|------|------------------|-------------|
+| `llms_txt` | Yes | No | llms.txt structured documentation |
+| `jina` | Yes | No | Jina Reader (20 RPM free tier) |
+| `firecrawl` | No | FIRECRAWL_API_KEY | Deep extraction with JS rendering |
+| `direct_fetch` | Yes | No | Direct HTTP fetch + HTML-to-text |
+| `mistral_browser` | No | MISTRAL_API_KEY | AI-powered browser agent |
+| `docling` | No | No | PDF/DOCX/PPTX processing |
+| `ocr` | No | No | Image OCR (Tesseract) |
+
+## Provider Details
+
+### Exa MCP (FREE)
+
+- **Endpoint**: https://mcp.exa.ai/mcp
+- **Protocol**: JSON-RPC 2.0 over HTTP POST
+- **Rate Limit**: 30s cooldown on 429
+- **Best For**: Technical documentation, code examples
+
+### Exa SDK
+
+- **Features**: Token-efficient highlights, semantic search
+- **Rate Limit**: 60s cooldown on 429
+- **Best For**: High-quality research results
+
+### Tavily
+
+- **Features**: Comprehensive search, content extraction
+- **Rate Limit**: 60s cooldown on 429
+- **Best For**: Broad web research
+
+### Serper
+
+- **Features**: Google search results
+- **Free Tier**: 2500 credits
+- **Rate Limit**: 60s cooldown on 429
+- **Best For**: Google-indexed content
+
+### DuckDuckGo (FREE)
+
+- **Features**: No authentication needed
+- **Rate Limit**: 30s cooldown on 429
+- **Best For**: Always-available fallback
+
+### llms.txt (FREE)
+
+- **Check**: `{origin}/llms.txt`
+- **Cache**: 1-hour TTL per origin
+- **Best For**: Documentation sites with structured docs
+
+### Jina Reader (FREE)
+
+- **Endpoint**: `https://r.jina.ai/{url}`
+- **Rate Limit**: 20 requests per minute
+- **Best For**: Clean markdown extraction from any URL
+
+### Direct Fetch (FREE)
+
+- **Method**: HTTP GET + HTML parsing
+- **Features**: Script/style removal, whitespace normalization
+- **Best For**: Simple static pages
+
+## Rate Limit Handling
+
+All providers implement automatic rate limit handling:
+
+1. Detect 429 status code or "rate limit" in response
+2. Set provider-specific cooldown period
+3. Skip provider during cooldown
+4. Continue to next provider in cascade
+
+## Circuit Breaker Pattern
+
+Each provider has an independent circuit breaker:
+
+```
+CLOSED → (3 failures) → OPEN → (5 min cooldown) → HALF_OPEN → (success) → CLOSED
+                         ↑                           ↓
+                         └───── (failure) ───────────┘
+```

--- a/.claude/skills/do-web-doc-resolver
+++ b/.claude/skills/do-web-doc-resolver
@@ -1,0 +1,1 @@
+../../.agents/skills/do-web-doc-resolver

--- a/.gemini/skills/do-web-doc-resolver
+++ b/.gemini/skills/do-web-doc-resolver
@@ -1,0 +1,1 @@
+../../.agents/skills/do-web-doc-resolver


### PR DESCRIPTION
## Summary

Adds the `do-web-doc-resolver` skill based on [d-oit/do-web-doc-resolver](https://github.com/d-oit/do-web-doc-resolver) - an intelligent web documentation resolver with Python core, Rust CLI, and multi-provider cascade.

## Features

- **Free-first cascade**: Works without API keys using Exa MCP, DuckDuckGo, llms.txt, Jina Reader
- **Multi-provider routing**: Exa, Tavily, Serper, Firecrawl, Mistral with automatic fallback
- **Circuit breakers**: Per-provider failure tracking with 5-minute cooldowns
- **Routing memory**: Per-domain provider success rate learning
- **Quality scoring**: Content scored 0.0-1.0 based on multiple signals
- **Execution profiles**: `free`, `fast`, `balanced`, `quality` modes

## Skill Structure

```
do-web-doc-resolver/
├── SKILL.md              # Main skill (125 lines)
├── evals/evals.json      # 8 evaluation cases
└── reference/
    ├── cascade.md        # Decision trees
    ├── providers.md      # Provider details
    └── configuration.md  # Config reference
```

## Test Plan

- [x] Quality gate passes
- [x] Skill validation passes
- [x] Symlinks created for Claude Code and Gemini CLI
- [x] SKILL.md under 250 lines
- [x] YAML frontmatter has name and description