### PR TITLE
fix: resolve YAML lint failures and pre-existing warnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+---
 blank_issues_enabled: true
 contact_links:
   - name: Questions & Discussions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   # GitHub Actions

--- a/.github/workflows/ci-and-labels.yml
+++ b/.github/workflows/ci-and-labels.yml
@@ -1,5 +1,7 @@
+---
 name: CI + Labels Setup
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:
@@ -64,7 +66,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-        if: hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('.agents/skills/*/requirements.txt') != '' || hashFiles('.agents/skills/*/pyproject.toml') != ''
+        if: >-
+          hashFiles('requirements.txt') != '' ||
+          hashFiles('pyproject.toml') != '' ||
+          hashFiles('.agents/skills/*/requirements.txt') != '' ||
+          hashFiles('.agents/skills/*/pyproject.toml') != ''
 
       - name: Setup Go (if go.mod exists)
         uses: actions/setup-go@v5
@@ -79,7 +85,11 @@ jobs:
       - name: Install dependencies (Python)
         run: |
           pip install ruff black pytest
-        if: hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('.agents/skills/*/requirements.txt') != '' || hashFiles('.agents/skills/*/pyproject.toml') != ''
+        if: >-
+          hashFiles('requirements.txt') != '' ||
+          hashFiles('pyproject.toml') != '' ||
+          hashFiles('.agents/skills/*/requirements.txt') != '' ||
+          hashFiles('.agents/skills/*/pyproject.toml') != ''
 
       - name: Run quality gate
         run: ./scripts/quality_gate.sh
@@ -108,7 +118,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-        if: hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('.agents/skills/*/requirements.txt') != '' || hashFiles('.agents/skills/*/pyproject.toml') != ''
+        if: >-
+          hashFiles('requirements.txt') != '' ||
+          hashFiles('pyproject.toml') != '' ||
+          hashFiles('.agents/skills/*/requirements.txt') != '' ||
+          hashFiles('.agents/skills/*/pyproject.toml') != ''
 
       - name: Setup Go (if go.mod exists)
         uses: actions/setup-go@v5

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,6 +1,7 @@
 ---
 name: YAML Lint
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

Fixes YAML Lint workflow failures on main branch by resolving pre-existing yamllint violations.

## Changes

- Add document start `---` to `dependabot.yml`, `config.yml`, `ci-and-labels.yml`
- Add `yamllint disable-line` for truthy rule on `on:` key in workflow files
- Break long `hashFiles` conditions into multi-line YAML format (120 char limit)

## Verification

```
yamllint -d "{extends: default, rules: {line-length: {max: 120}, indentation: {spaces: 2}}}" .github/
```

All YAML files pass linting locally.