### PR TITLE
fix: update documentation, improve .gitignore, and fix broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,31 @@
 .DS_Store
 Thumbs.db
 
+# Editor files
+*.swp
+*.swo
+*~
+.idea/
+.vscode/
+
 # Node modules
 node_modules/
 
 # Python
 __pycache__/
 *.pyc
+*.pyo
+*.pyd
+.venv/
+venv/
+.pytest_cache/
+.coverage
+*.egg-info/
+
+# Rust
+target/
+*.o
+*.a
 
 # Logs
 *.log
@@ -15,3 +34,12 @@ __pycache__/
 # Build outputs
 dist/
 build/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store
+Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,15 @@ Always run the full quality gate before committing. Fix all errors before finish
 ├── AGENTS.md              # This file - agent instructions (single source of truth)
 ├── CLAUDE.md              # Claude Code-specific overrides only (@AGENTS.md)
 ├── GEMINI.md              # Gemini CLI-specific overrides only (@AGENTS.md)
+├── QWEN.md                # Qwen Code-specific overrides only (@AGENTS.md)
 ├── agents-docs/           # Detailed reference docs (loaded on demand, not by default)
 │   ├── HARNESS.md         # MCP, skills, sub-agents, hooks overview
 │   ├── SKILLS.md          # Skill authoring and progressive disclosure
 │   ├── SUB-AGENTS.md      # Context isolation patterns
 │   ├── HOOKS.md           # Hook configuration and verification
 │   ├── CONTEXT.md         # Context engineering and back-pressure
-│   └── RUST.md            # Rust-specific patterns (remove if not Rust)
+│   ├── RUST.md            # Rust-specific patterns (remove if not Rust)
+│   └── AGENTS_REGISTRY.md # Auto-generated registry of all sub-agents
 ├── .agents/
 │   └── skills/            # CANONICAL skill source - all agents read from here
 │       └── <skill-name>/
@@ -68,11 +70,15 @@ Always run the full quality gate before committing. Fix all errors before finish
 │   └── commands/
 ├── .gemini/
 │   └── skills/            # Symlinks -> ../../.agents/skills/<name>
+├── .qwen/
+│   └── skills/            # Symlinks -> ../../.agents/skills/<name>
 ├── scripts/
 │   ├── setup-skills.sh    # Creates all symlinks (run on clone)
 │   ├── validate-skills.sh # Validates all symlinks are intact
 │   ├── quality_gate.sh    # Full pre-commit quality gate
-│   └── pre-commit-hook.sh # Git hook entry point
+│   ├── pre-commit-hook.sh # Git hook entry point
+│   ├── gh-labels-creator.sh # GitHub label initialization
+│   └── update-agents-registry.sh # Regenerates AGENTS_REGISTRY.md
 ├── README.md
 └── .github/workflows/
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Production-ready template for AI agent-powered development with Claude Code, Gemini CLI, OpenCode, Qwen Code, and more.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Template Version](https://img.shields.io/badge/version-0.2.0-blue)](VERSION)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
@@ -165,7 +165,7 @@ We welcome contributions! See our [Contributing Guide](CONTRIBUTING.md) for:
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE) - see the LICENSE file for details.
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT) - see the LICENSE file for details.
 
 ---
 

--- a/agents-docs/AGENTS_REGISTRY.md
+++ b/agents-docs/AGENTS_REGISTRY.md
@@ -25,7 +25,7 @@ Agents are organized by CLI tool and purpose.
 ## Available Skills
 
 Skills are reusable knowledge modules with progressive disclosure.
-See [`agents-docs/SKILLS.md`](agents-docs/SKILLS.md) for authoring guide.
+See [`SKILLS.md`](SKILLS.md) for authoring guide.
 
 | Skill | Location | Description |
 |-------|----------|-------------|


### PR DESCRIPTION
## Summary

Fix documentation inconsistencies and improve .gitignore coverage based on swarm agent verification findings.

## Changes

**README.md**:
- Fix LICENSE badge pointing to non-existent file (use opensource.org URL)

**AGENTS.md**:
- Add QWEN.md and .qwen/ directory to structure diagram
- Add AGENTS_REGISTRY.md to agents-docs listing
- Add missing scripts: gh-labels-creator.sh, update-agents-registry.sh

**AGENTS_REGISTRY.md**:
- Fix broken relative link (agents-docs/SKILLS.md -> SKILLS.md)

**.gitignore**:
- Add .env, .env.* (secrets protection)
- Add .venv/, venv/ (Python virtual environments)
- Add .pytest_cache/, .coverage (test artifacts)
- Add *.pyo, *.pyd, *.egg-info/ (Python artifacts)
- Add .vscode/, .idea/, *.swp, *.swo (editor files)
- Add target/, *.o, *.a (Rust build output)