### PR TITLE
Add generic `learn` skill for post-task knowledge capture

### DIFF
--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: learn
+description: Extract non-obvious session learnings into scoped AGENTS.md files
+category: knowledge-management
+trigger: after non-trivial task completion
+---
+
+# Learn
+
+Extract non-obvious session learnings into scoped `AGENTS.md` files to preserve knowledge across sessions.
+
+## When to Use
+
+Activate after completing a non-trivial task to capture insights that would otherwise be lost.
+
+## Instructions
+
+### What to Capture (Non-Obvious Only)
+
+- Hidden relationships between files or scripts not obvious from code.
+- Execution paths that differ from what the code appears to do.
+- Non-obvious config, env vars, or flags (see `agents-docs/ENVIRONMENT_VARIABLES.md`).
+- Debugging breakthroughs where error messages were misleading.
+- Files that must change together (e.g., `AGENTS.md` + `agents-docs/AVAILABLE_SKILLS.md` when adding skills).
+- Build/test commands not documented in README.
+- Architectural constraints discovered at runtime.
+
+### What NOT to Capture
+
+- Obvious documentation or standard behavior.
+- Duplicates of existing entries.
+- Verbose explanations or session-specific notes.
+
+### Scoping Rules
+
+Place learnings in the most specific `AGENTS.md` file:
+- **Project-wide**: Root `AGENTS.md`.
+- **Script-specific**: `scripts/AGENTS.md`.
+- **Skill-specific**: `.agents/skills/<name>/AGENTS.md`.
+
+### Format
+
+- 1–3 lines per insight.
+- Fits within `MAX_LINES_AGENTS_MD=150` constraint.
+- Bulleted list under a "Learnings" or "Context" section.
+
+## Reference Files
+
+- `agents-docs/LESSONS.md` - Legacy project-wide lessons.
+- `AGENTS.md` - Root agent guidance and constraints.

--- a/.claude/skills/learn
+++ b/.claude/skills/learn
@@ -1,0 +1,1 @@
+../../.agents/skills/learn

--- a/.gemini/skills/learn
+++ b/.gemini/skills/learn
@@ -1,0 +1,1 @@
+../../.agents/skills/learn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ git checkout -b feat/your-feature-name
 ### Context Discipline
 - Delegate research to sub-agents; Use `/clear` between unrelated tasks
 - Load skills only when needed; See `agents-docs/SKILLS.md` for skill framework
+- **Post-task**: Use `learn` skill to capture non-obvious insights in scoped `AGENTS.md` files
 
 ### Nested AGENTS.md
 For monorepos, place additional `AGENTS.md` inside each sub-package. Nearest file takes precedence.

--- a/agents-docs/AGENTS_REGISTRY.md
+++ b/agents-docs/AGENTS_REGISTRY.md
@@ -1,7 +1,7 @@
 # Agents Registry
 
 > Auto-generated registry of all sub-agents in this repository.
-> Last updated: 2026-04-04 08:30 UTC
+> Last updated: 2026-04-04 16:31 UTC
 
 This file provides a centralized discovery mechanism for all available sub-agents.
 Agents are organized by CLI tool and purpose.
@@ -49,10 +49,12 @@ See [`agents-docs/SKILLS.md`](agents-docs/SKILLS.md) for authoring guide.
 | `goap-agent` | `.agents/skills/goap-agent` | Invoke for complex multi-step tasks requiring intelligent pl |
 | `intent-classifier` | `.agents/skills/intent-classifier` | Classify user intents and route to appropriate skills, comma |
 | `iterative-refinement` | `.agents/skills/iterative-refinement` | Execute iterative refinement workflows with validation loops |
+| `learn` | `.agents/skills/learn` | Extract non-obvious session learnings into scoped AGENTS.md  |
 | `migration-refactoring` | `.agents/skills/migration-refactoring` | Automate complex code migrations and refactorings with safet |
 | `parallel-execution` | `.agents/skills/parallel-execution` | Execute multiple independent tasks simultaneously using para |
 | `privacy-first` | `.agents/skills/privacy-first` | Prevent email addresses and personal data from entering the  |
 | `security-code-auditor` | `.agents/skills/security-code-auditor` | Perform security audits on code to identify vulnerabilities, |
+| `self-fix-loop` | `.agents/skills/self-fix-loop` | Self-learning fix loop - commit, push, monitor CI, auto-fix  |
 | `shell-script-quality` | `.agents/skills/shell-script-quality` | Lint and test shell scripts using ShellCheck and BATS. Use w |
 | `skill-creator` | `.agents/skills/skill-creator` | Create new skills, modify and improve existing skills, and m |
 | `skill-evaluator` | `.agents/skills/skill-evaluator` | "Reusable skill for evaluating other skills with structure c |

--- a/agents-docs/AVAILABLE_SKILLS.md
+++ b/agents-docs/AVAILABLE_SKILLS.md
@@ -51,6 +51,11 @@
 | `do-web-doc-resolver` | Resolve URLs and queries into compact, LLM-ready markdown |
 | `web-search-researcher` | Research topics using web search |
 
+### Knowledge Management
+| Skill | Description |
+|-------|-------------|
+| `learn` | Extract non-obvious session learnings into scoped AGENTS.md files |
+
 ### Meta (Skill Management)
 | Skill | Description |
 |-------|-------------|


### PR DESCRIPTION
This change implements a new `learn` skill designed to capture and preserve non-obvious session learnings in scoped `AGENTS.md` files. This helps maintain context across AI sessions regardless of the CLI tool used. The skill includes clear inclusion/exclusion rules and scoping logic to ensure insights are placed in the most relevant `AGENTS.md` file. The root `AGENTS.md` and skill registries have been updated to promote and document this new capability.

Fixes #110

---
*PR created automatically by Jules for task [5870486354362593598](https://jules.google.com/task/5870486354362593598) started by @d-o-hub*