### PR TITLE
fix(ci): correct labeler SHA and add retry logic to dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,20 +20,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: checks } = await github.rest.checks.listForRef({
-              ...context.repo,
-              ref: context.payload.pull_request.head.sha
-            });
-            const pending = checks.check_runs.filter(c => c.status !== 'completed');
-            if (pending.length > 0) {
-              core.setFailed('Checks still running');
+            const MAX_RETRIES = 12;
+            const POLL_INTERVAL_MS = 30000; // 30 seconds
+            for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+              const { data: checks } = await github.rest.checks.listForRef({
+                ...context.repo,
+                ref: context.payload.pull_request.head.sha
+              });
+              const pending = checks.check_runs.filter(c => c.status !== 'completed');
+              if (pending.length === 0) {
+                const failures = checks.check_runs.filter(c =>
+                  c.conclusion === 'failure' || c.conclusion === 'cancelled'
+                );
+                if (failures.length > 0) {
+                  core.setFailed('Some checks failed');
+                }
+                return;
+              }
+              if (attempt < MAX_RETRIES - 1) {
+                await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+              }
             }
-            const failures = checks.check_runs.filter(c =>
-              c.conclusion === 'failure' || c.conclusion === 'cancelled'
-            );
-            if (failures.length > 0) {
-              core.setFailed('Some checks failed');
-            }
+            core.setFailed('Timeout waiting for checks to complete');
 
       - name: Auto-merge Dependabot PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,7 +20,7 @@ jobs:
             .github/labeler.yml
           sparse-checkout-cone-mode: false
 
-      - uses: actions/labeler@8558fd74191d9d90789e6c7e0b8b8b8b8b8b8b8b  # v5.0.0
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Summary

- Fix invalid SHA for  (was padded/fake, now correct )
- Add retry/polling logic to Dependabot auto-merge workflow (max 12 attempts, 30s interval) to handle race condition where checks haven't completed yet

## Why

The labeler workflow was failing with:
```
Unable to resolve action `actions/labeler@8558fd74191d9d90789e6c7e0b8b8b8b8b8b8b8b`, unable to find version
```

The Dependabot auto-merge was failing immediately because it ran before other checks completed, instead of waiting with retries.

Fixes CI failures on all Dependabot PRs.
