### PR TITLE
feat: add version field to SKILL.md and MAX_CONTEXT_TOKENS constants

### DIFF
--- a/.agents/skills/api-design-first/SKILL.md
+++ b/.agents/skills/api-design-first/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: api-design-first
 description: Design and document RESTful APIs using design-first principles with OpenAPI specifications. Use when users ask to 'design an API', 'create API spec', 'REST API', 'OpenAPI', 'Swagger', or 'API documentation'. Trigger on API design tasks, endpoint planning, request/response modeling, or API versioning discussions.
+version: "1.0"
+template_version: "0.2"
 license: MIT
 ---
 

--- a/.agents/skills/security-code-auditor/SKILL.md
+++ b/.agents/skills/security-code-auditor/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: security-code-auditor
 description: Perform security audits on code to identify vulnerabilities, misconfigurations, and security anti-patterns. Use when users ask to 'audit', 'review', or 'check security' of code, configurations, or repositories. Trigger on keywords like 'security review', 'vulnerability scan', 'OWASP', 'secure coding', 'penetration test', or 'security assessment'.
+version: "1.0"
+template_version: "0.2"
 license: MIT
 ---
 

--- a/.agents/skills/self-fix-loop/SKILL.md
+++ b/.agents/skills/self-fix-loop/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: self-fix-loop
 description: Self-learning fix loop - commit, push, monitor CI, auto-fix failures using swarm agents with skills on demand, loop until all checks pass.
+version: "1.0"
+template_version: "0.2"
 ---
 
 # Self-Fix Loop Skill

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -39,6 +39,8 @@ skill-name/
 |-------|----------|-------------|
 | `name` | Yes | Max 64 chars. Lowercase letters, numbers, hyphens only. |
 | `description` | Yes | Max 1024 chars. Describes what the skill does AND when to use it. |
+| `version` | Recommended | Semantic version of the skill itself (e.g., "1.0"). |
+| `template_version` | Recommended | Minimum template version required (matches VERSION file). |
 | `license` | No | License name or reference to bundled license file. |
 | `compatibility` | No | Max 500 chars. Environment requirements. |
 | `metadata` | No | Arbitrary key-value mapping. |

--- a/.agents/skills/test-runner/SKILL.md
+++ b/.agents/skills/test-runner/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: test-runner
 description: Execute tests, analyze results, and diagnose failures across any testing framework. Use when running test suites, debugging failing tests, or configuring CI/CD testing pipelines.
+version: "1.0"
+template_version: "0.2"
 license: MIT
 ---
 

--- a/agents-docs/SKILLS.md
+++ b/agents-docs/SKILLS.md
@@ -41,6 +41,14 @@ when the agent decides it is needed. Do not pre-load all skills at session start
 ## SKILL.md Template
 
 ```markdown
+---
+name: skill-name
+description: One-line description
+category: coordination|quality|documentation|workflow|research|knowledge-management
+version: "1.0"
+template_version: "0.2"
+---
+
 # Skill Name
 
 Brief description.
@@ -58,6 +66,19 @@ Activate when: [specific triggers]
 ## Examples
 [Concrete usage]
 ```
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier (lowercase, hyphens) |
+| `description` | Yes | One-line description with trigger keywords |
+| `category` | Yes | One of: coordination, quality, documentation, workflow, research, knowledge-management |
+| `version` | Recommended | Semantic version of the skill itself (e.g., "1.0") |
+| `template_version` | Recommended | Minimum template version this skill requires (matches VERSION file) |
+
+`version` and `template_version` enable `validate-skills.sh` to detect stale skills
+and help template consumers know which template version a skill was authored for.
 
 ## Rules
 

--- a/scripts/lib/skill-validation.sh
+++ b/scripts/lib/skill-validation.sh
@@ -47,6 +47,29 @@ validate_skill_file() {
         ((errors++))
     fi
 
+    # Warn if missing version field (non-breaking)
+    if ! grep -q "^version:" "$skill_file" 2>/dev/null; then
+        echo -e "  ${YELLOW}⚠${NC} $skill_name: Missing 'version:' field (recommended)" >&2
+    fi
+
+    # Warn if template_version is older than current by more than one minor version
+    if grep -q "^template_version:" "$skill_file" 2>/dev/null; then
+        local current_version skill_template_version
+        current_version=$(cat "$REPO_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]')
+        skill_template_version=$(grep "^template_version:" "$skill_file" | head -1 | sed 's/template_version: *//;s/"//g;s/ *$//')
+        if [[ -n "$current_version" && -n "$skill_template_version" ]]; then
+            local current_major current_minor skill_major skill_minor
+            current_major=$(echo "$current_version" | cut -d. -f1)
+            current_minor=$(echo "$current_version" | cut -d. -f2)
+            skill_major=$(echo "$skill_template_version" | cut -d. -f1)
+            skill_minor=$(echo "$skill_template_version" | cut -d. -f2)
+            if [[ "$skill_major" -lt "$current_major" ]] || \
+               { [[ "$skill_major" -eq "$current_major" ]] && [[ $((current_minor - skill_minor)) -gt 1 ]]; }; then
+                echo -e "  ${YELLOW}⚠${NC} $skill_name: template_version $skill_template_version is >1 minor behind current $current_version" >&2
+            fi
+        fi
+    fi
+
     # Check line count
     local line_count
     line_count=$(wc -l < "$skill_file" | tr -d ' ')

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -66,6 +66,29 @@ for skill_path in "$SKILLS_SRC"/*/; do
         FAILED=1
     fi
 
+    # Check 2b: Warn if missing version field (non-breaking)
+    if ! grep -q "^version:" "$skill_path/SKILL.md" 2>/dev/null; then
+        echo -e "  ${YELLOW}⚠${NC} $skill_name: Missing 'version:' field (recommended)" >&2
+        WARNINGS=1
+    fi
+
+    # Check 2c: Warn if template_version is older than current by >1 minor version
+    if grep -q "^template_version:" "$skill_path/SKILL.md" 2>/dev/null; then
+        current_version=$(cat "$REPO_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]')
+        skill_template_version=$(grep "^template_version:" "$skill_path/SKILL.md" | head -1 | sed 's/template_version: *//;s/"//g;s/ *$//')
+        if [[ -n "$current_version" && -n "$skill_template_version" ]]; then
+            current_major=$(echo "$current_version" | cut -d. -f1)
+            current_minor=$(echo "$current_version" | cut -d. -f2)
+            skill_major=$(echo "$skill_template_version" | cut -d. -f1)
+            skill_minor=$(echo "$skill_template_version" | cut -d. -f2)
+            if [[ "$skill_major" -lt "$current_major" ]] || \
+               { [[ "$skill_major" -eq "$current_major" ]] && [[ $((current_minor - skill_minor)) -gt 1 ]]; }; then
+                echo -e "  ${YELLOW}⚠${NC} $skill_name: template_version $skill_template_version is >1 minor behind current $current_version" >&2
+                WARNINGS=1
+            fi
+        fi
+    fi
+
     # Check 3: SKILL.md line count (<= MAX_SKILL_LINES)
     line_count=$(wc -l < "$skill_path/SKILL.md" | tr -d ' ')
     if [ "$line_count" -gt "$MAX_SKILL_LINES" ]; then


### PR DESCRIPTION
## Summary
- Add version and template_version fields to SKILL.md frontmatter spec
- Add validation warnings for missing version in validate-skills.sh and skill-validation.sh
- Update 4 newest skills (self-fix-loop, test-runner, api-design-first, security-code-auditor) with version metadata
- Add MAX_CONTEXT_TOKENS, MAX_SUB_AGENT_TOKENS, MAX_SKILL_REFERENCE_LINES to AGENTS.md
- Update skill-creator scaffolding to include version fields

Closes #113, #116