### PR TITLE
feat(skill): add ci-autofix skill + fix(ci): resolve yamllint rule:truthy in version-propagation.yml

### DIFF
--- a/.agents/skills/ci-autofix/SKILL.md
+++ b/.agents/skills/ci-autofix/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: ci-autofix
+description: Detect and automatically fix failing CI pipelines using OpenCode CLI with Ollama Cloud. Reads open GitHub Actions runs, analyzes errors, researches fixes against official documentation, and applies safe auto-fixes only when the solution is unambiguous and documentation-validated.
+license: MIT
+---
+
+# CI Autofix
+
+Automatically detect failing CI jobs, analyze root causes, and apply safe auto-fixes using OpenCode CLI with Ollama Cloud — only when the fix is clearly documented and unambiguous.
+
+## When to Use
+
+- **Failing GitHub Actions runs** — YAML lint errors, syntax issues, deprecated actions
+- **Known linter false positives** — yamllint `rule:truthy` on `on:` keys in GitHub Actions
+- **Documented fix patterns** — issues with a clear, official-documentation-backed solution
+- **Recurring CI failures** — same error appearing across multiple workflow files
+- **Post-commit validation** — verify all workflows pass after changes
+
+## Core Principles
+
+> **Safety First**: Only apply fixes when the solution is 100% clear from official documentation (yamllint docs, GitHub Actions docs, action changelogs). Never assume or guess a fix.
+
+- Research the error against official docs before applying any change
+- If multiple fix options exist with trade-offs → **stop, report to user, do not auto-fix**
+- If the error cause is ambiguous → **stop, report to user, do not auto-fix**
+- If the fix requires logic changes (not just syntax) → **stop, report to user**
+
+## Core Workflow
+
+### Phase 1: Detect Failures
+
+1. Read the current GitHub Actions run from the open browser tab
+2. Identify all failing jobs and their error messages
+3. Locate the affected workflow files in `.github/workflows/`
+4. Extract the exact error lines and context
+
+### Phase 2: Research & Validate Fix
+
+1. Search official documentation for the exact error
+   - yamllint docs: https://yamllint.readthedocs.io/
+   - GitHub Actions docs: https://docs.github.com/en/actions
+   - Action-specific changelogs and release notes
+2. Confirm the fix is documented and unambiguous
+3. Verify no alternative interpretations exist
+4. Check if the fix is purely syntactic (safe) or semantic (requires human review)
+
+### Phase 3: Auto-Fix with OpenCode CLI + Ollama Cloud
+
+Only proceed if Phase 2 confirms a clear, documented fix.
+
+```bash
+# Configure OpenCode with Ollama Cloud provider
+# opencode.json (project-level or ~/.config/opencode/config.json)
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama Cloud",
+      "options": {
+        "baseURL": "https://ollama.com/v1",
+        "apiKey": "${OLLAMA_API_KEY}"
+      },
+      "models": {
+        "qwen3-coder:cloud": {
+          "name": "qwen3-coder:cloud"
+        }
+      }
+    }
+  },
+  "model": "ollama/qwen3-coder:cloud"
+}
+```
+
+```bash
+# Run the fix via OpenCode CLI (non-interactive / headless)
+opencode run --model ollama/qwen3-coder:cloud \
+  "Fix the yamllint error in .github/workflows/<file>.yml. \
+   The error is: <exact error>. \
+   The fix is documented at <source URL>: add '# yamllint disable-line rule:truthy' \
+   as an inline comment on the line containing 'on:'. \
+   Apply only this change, nothing else."
+```
+
+### Phase 4: Verify
+
+1. Run yamllint locally to confirm fix: `yamllint -d '{extends: default}' .github/workflows/*.yml`
+2. Commit with conventional message: `fix(ci): resolve yamllint <rule> in <filename>`
+3. Push and confirm CI passes
+
+## Known Fix Patterns
+
+See `references/fix-patterns.md` for documented, validated fix patterns.
+
+### Pattern: yamllint `rule:truthy` on `on:` key
+
+**Error**: `[error] truthy value should be one of [false, true] (rule:truthy)`
+
+**Root Cause**: yamllint interprets YAML `on:` key as a truthy boolean (`on` = `true` in YAML 1.1 spec). GitHub Actions uses `on:` as an event trigger keyword.
+
+**Official Fix** ([yamllint docs](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy), [GitHub Actions community](https://github.com/adrienverge/yamllint/issues/430)):
+
+Add `# yamllint disable-line rule:truthy` as an inline comment **on the same line** as `on:`:
+
+```yaml
+# WRONG - comment on preceding line (disable-line does not work)
+# yamllint disable-line rule:truthy
+on:
+
+# CORRECT - inline comment on same line
+on: # yamllint disable-line rule:truthy
+  push:
+    ...
+```
+
+**Confidence**: HIGH — single unambiguous documented fix, no side effects.
+
+**OpenCode CLI command**:
+```bash
+opencode run --model ollama/qwen3-coder:cloud \
+  "In .github/workflows/version-propagation.yml, the line 'on:' triggers a yamllint truthy error. \
+   Fix: add '# yamllint disable-line rule:truthy' as an inline comment on the same 'on:' line. \
+   Result should be: 'on: # yamllint disable-line rule:truthy'. Apply only this exact change."
+```
+
+## Decision Tree: Fix or Escalate?
+
+```
+CI Failure detected
+       |
+       v
+Is error message exact and specific?
+  No  --> STOP: Report to user, ask for clarification
+  Yes |
+       v
+Is fix documented in official docs?
+  No  --> STOP: Do not guess, report to user
+  Yes |
+       v
+Is fix purely syntactic (no logic change)?
+  No  --> STOP: Escalate to human review
+  Yes |
+       v
+Is there exactly ONE valid fix?
+  No  --> STOP: Present options to user
+  Yes |
+       v
+Apply fix via OpenCode CLI + Ollama Cloud
+       |
+       v
+Verify locally before committing
+```
+
+## OpenCode CLI Integration
+
+### Setup
+
+```bash
+# Install OpenCode CLI
+npm install -g opencode-ai
+
+# Connect Ollama Cloud (requires ollama.com account + API key)
+# Option A: via /connect command in TUI
+opencode  # then run: /connect -> search "Ollama Cloud"
+
+# Option B: manual config in opencode.json
+# See configuration block in Phase 3 above
+
+# Verify connection
+opencode run --model ollama/qwen3-coder:cloud "echo hello"
+```
+
+### Headless / Scripted Usage
+
+```bash
+# Run fix non-interactively (for use in scripts or other agents)
+opencode run --model ollama/qwen3-coder:cloud --print "<prompt>"
+
+# With explicit working directory
+opencode run --cwd /path/to/repo --model ollama/qwen3-coder:cloud "<prompt>"
+```
+
+## Quality Checklist
+
+- [ ] Error message read directly from CI logs (no assumptions)
+- [ ] Fix source is official documentation URL (not Stack Overflow, blog posts)
+- [ ] Fix is syntactic-only (no behavioral changes)
+- [ ] Single unambiguous fix exists
+- [ ] Local yamllint validation passes after fix
+- [ ] Commit message follows conventional commits format
+- [ ] CI re-run confirms green status
+- [ ] No unrelated files modified
+
+## References
+
+- `references/fix-patterns.md` — Validated fix patterns with documentation sources
+- yamllint rules: https://yamllint.readthedocs.io/en/stable/rules.html
+- GitHub Actions `on:` syntax: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+- OpenCode providers: https://opencode.ai/docs/providers/
+- Ollama Cloud setup: https://ollama.com/docs/integrations/opencode

--- a/.agents/skills/ci-autofix/evals/evals.json
+++ b/.agents/skills/ci-autofix/evals/evals.json
@@ -1,0 +1,54 @@
+{
+  "skill_name": "ci-autofix",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "The GitHub Actions run for this commit is failing with a YAML lint error in .github/workflows/version-propagation.yml. The error is: '[error] truthy value should be one of [false, true] (rule:truthy)' on the line containing 'on:'. Fix it using OpenCode CLI with Ollama Cloud.",
+      "expected_output": "The agent identifies the yamllint rule:truthy false positive on the 'on:' key, confirms the fix from official yamllint documentation, and applies exactly: 'on: # yamllint disable-line rule:truthy' in version-propagation.yml using OpenCode CLI with the ollama/qwen3-coder:cloud model. No other lines are modified.",
+      "assertions": [
+        "The agent reads the CI error from the open browser tab or provided log",
+        "The agent identifies the file as version-propagation.yml",
+        "The agent references official yamllint docs or a validated GitHub issue",
+        "The agent applies the fix inline on the 'on:' line (not on a preceding line)",
+        "The agent uses OpenCode CLI with ollama/qwen3-coder:cloud model",
+        "The agent verifies with yamllint locally before committing",
+        "The agent does NOT modify any other lines"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Multiple workflow files in .github/workflows/ are failing yamllint with truthy errors. Scan all workflow files and fix only the ones with documented, unambiguous fixes.",
+      "expected_output": "The agent scans all .github/workflows/*.yml files, identifies each 'on:' line missing the yamllint disable comment, applies the inline comment fix to each affected file via OpenCode CLI with Ollama Cloud, and skips any files where the error cause is different or unclear.",
+      "assertions": [
+        "The agent uses glob to find all .github/workflows/*.yml files",
+        "The agent identifies each file with a yamllint rule:truthy error",
+        "The agent applies the fix only where it is unambiguous",
+        "The agent reports files skipped due to unclear errors",
+        "The agent runs yamllint verification after all fixes"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "A CI job is failing with 'Error: Process completed with exit code 1' but the log shows only a generic error with no specific line number or rule. Should the agent auto-fix this?",
+      "expected_output": "The agent correctly identifies that the error is ambiguous (no specific rule, no line number), applies the decision tree, and escalates to the user instead of attempting an auto-fix. The agent provides the raw error output and asks the user for guidance.",
+      "assertions": [
+        "The agent does NOT attempt to auto-fix an ambiguous error",
+        "The agent correctly applies the decision tree: ambiguous error -> escalate",
+        "The agent reports the raw error to the user",
+        "The agent asks the user for clarification or next steps"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Fix the yamllint error in .github/workflows/dedup-issues.yml where the disable-line comment is on the line BEFORE 'on:' instead of inline.",
+      "expected_output": "The agent detects that the comment is on the wrong line (preceding line instead of inline), references the yamllint disable-line documentation to confirm that the comment must be on the same line, moves the comment to be inline on the 'on:' line, removes the now-orphaned preceding comment line, and verifies the fix.",
+      "assertions": [
+        "The agent detects the misplaced disable-line comment",
+        "The agent references yamllint documentation for disable-line behavior",
+        "The agent places the comment inline: 'on: # yamllint disable-line rule:truthy'",
+        "The agent removes the orphaned preceding comment if present",
+        "The agent verifies the fix with yamllint"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/ci-autofix/references/fix-patterns.md
+++ b/.agents/skills/ci-autofix/references/fix-patterns.md
@@ -1,0 +1,132 @@
+# CI Autofix — Validated Fix Patterns
+
+This reference contains ONLY fix patterns that are:
+- Documented in official sources
+- Unambiguous (single correct fix)
+- Safe to apply automatically (syntactic, no behavioral change)
+
+---
+
+## Pattern 001: yamllint `rule:truthy` false positive on `on:` key
+
+**Applies to**: GitHub Actions workflow YAML files  
+**Error message**: `[error] truthy value should be one of [false, true] (rule:truthy)`  
+**Affected files**: Any `.github/workflows/*.yml` with `on:` as the event trigger key  
+**Confidence**: HIGH — Auto-fix safe  
+
+### Root Cause
+
+YAML 1.1 spec treats `on` as a boolean truthy value (equivalent to `true`). yamllint enforces this by default via the `truthy` rule. GitHub Actions uses `on:` as an event trigger keyword — this is a well-known false positive.
+
+**Official Sources**:
+- yamllint truthy rule docs: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
+- yamllint issue #430 (GitHub Actions false positive): https://github.com/adrienverge/yamllint/issues/430
+- yamllint issue #540 (same, confirmed): https://github.com/adrienverge/yamllint/issues/540
+- yamllint issue #666 (same, confirmed): https://github.com/adrienverge/yamllint/issues/666
+
+### Fix
+
+Add `# yamllint disable-line rule:truthy` as an **inline comment on the same line** as `on:`.
+
+**IMPORTANT**: `disable-line` applies to the line it appears ON, not the next line.
+
+```yaml
+# BEFORE (causes error)
+on:
+  push:
+    branches: [main]
+
+# AFTER (fix applied)
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+```
+
+**Common Mistake** — comment on preceding line does NOT work:
+```yaml
+# WRONG: this does not suppress the error on the next line
+# yamllint disable-line rule:truthy
+on:
+```
+
+### OpenCode CLI Command
+
+```bash
+opencode run --model ollama/qwen3-coder:cloud \
+  "In .github/workflows/<FILENAME>.yml, find the line that contains only 'on:' \
+   (the GitHub Actions event trigger, usually near the top of the file). \
+   Add '# yamllint disable-line rule:truthy' as an inline comment on that exact line. \
+   The result must be: 'on: # yamllint disable-line rule:truthy'. \
+   Do not modify any other line. Do not add blank lines. Preserve all indentation."
+```
+
+### Verification
+
+```bash
+yamllint -d '{extends: default}' .github/workflows/<FILENAME>.yml
+# Expected: no errors (exit code 0)
+```
+
+---
+
+## Pattern 002: Deprecated `actions/checkout` SHA pinning warning
+
+**Applies to**: GitHub Actions workflows using `actions/checkout@<sha>`  
+**Error type**: Warning (actionlint), not yamllint  
+**Confidence**: HIGH — Auto-fix safe  
+
+### Fix
+
+Update to latest pinned SHA from https://github.com/actions/checkout/releases
+
+**Official Source**: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+
+### OpenCode CLI Command
+
+```bash
+opencode run --model ollama/qwen3-coder:cloud \
+  "In .github/workflows/<FILENAME>.yml, update 'actions/checkout@<OLD_SHA>' \
+   to 'actions/checkout@<NEW_SHA> # <VERSION_TAG>'. \
+   Use only the exact SHA provided. Do not modify any other step."
+```
+
+---
+
+## Pattern 003: Missing `permissions:` block (security hardening)
+
+**Applies to**: GitHub Actions workflows without explicit permissions  
+**Error type**: Best practice violation (not a CI error per se)  
+**Confidence**: MEDIUM — Requires human confirmation of scope  
+**Auto-fix**: NO — Escalate to human (permissions are semantic, not syntactic)
+
+### Reason Not Auto-Fixed
+
+The correct permission set depends on what the workflow does. Wrong permissions can break functionality or introduce security issues. Always present options to user.
+
+---
+
+## Escalation Patterns (Do NOT Auto-Fix)
+
+| Error Type | Reason to Escalate |
+|---|---|
+| Logic errors in workflow scripts | Behavioral change required |
+| Missing secrets or env vars | Infrastructure decision |
+| Action version upgrades (major) | Breaking changes possible |
+| Flaky tests / intermittent failures | Root cause unclear |
+| Matrix strategy changes | Semantic impact |
+| Concurrency/timeout settings | Performance trade-offs |
+| Permission scope changes | Security decision |
+
+---
+
+## Adding New Patterns
+
+To add a new validated fix pattern:
+
+1. Confirm error is 100% reproducible and unambiguous
+2. Find the fix in official documentation (not forums/blogs)
+3. Verify fix is purely syntactic (no behavioral change)
+4. Document source URL
+5. Add OpenCode CLI command template
+6. Mark confidence level: HIGH (auto-fix) or MEDIUM/LOW (escalate)
+7. Add verification command

--- a/.github/workflows/version-propagation.yml
+++ b/.github/workflows/version-propagation.yml
@@ -1,6 +1,6 @@
 name: Version Propagation
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     paths:
       - VERSION

--- a/.opencode/agents/ci-autofix.md
+++ b/.opencode/agents/ci-autofix.md
@@ -1,0 +1,203 @@
+---
+name: ci-autofix
+description: Detect and automatically fix failing CI pipelines. Reads open GitHub Actions runs, analyzes errors, validates fixes against official documentation, and applies safe auto-fixes using OpenCode CLI with Ollama Cloud. Only fixes issues with a single, unambiguous, documentation-backed solution.
+mode: subagent
+tools:
+  read: true
+  edit: true
+  write: true
+  websearch: true
+  glob: true
+  grep: true
+  bash: true
+---
+
+# CI Autofix Agent
+
+You are a specialized agent for detecting and fixing failing CI pipelines, specifically GitHub Actions. You apply auto-fixes **only** when the solution is unambiguous and validated against official documentation. You never guess or assume fixes.
+
+## Provider Configuration
+
+You use OpenCode CLI with Ollama Cloud as your execution backend:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama Cloud",
+      "options": {
+        "baseURL": "https://ollama.com/v1",
+        "apiKey": "${OLLAMA_API_KEY}"
+      },
+      "models": {
+        "qwen3-coder:cloud": {
+          "name": "qwen3-coder:cloud"
+        }
+      }
+    }
+  },
+  "model": "ollama/qwen3-coder:cloud"
+}
+```
+
+## Role
+
+You specialize in:
+
+- Reading GitHub Actions run logs from the open browser tab
+- Identifying exact error messages and affected workflow files
+- Researching fixes in official documentation (yamllint, GitHub Actions, action changelogs)
+- Applying safe, syntactic-only fixes via OpenCode CLI with Ollama Cloud
+- Escalating ambiguous or semantic errors to the user
+
+## Core Safety Rule
+
+> **Never apply a fix unless it is documented in official sources and there is exactly ONE valid solution.**
+
+If ANY of these conditions are true, STOP and escalate to user:
+- Error message is vague or non-specific
+- Fix requires logic or behavioral changes
+- Multiple fix options exist with different trade-offs
+- Fix source is not an official documentation page or validated GitHub issue
+- You are uncertain about the impact
+
+## Process
+
+### Step 1: Read CI Logs
+
+```bash
+# Read from open browser tab or use gh CLI
+gh run view <RUN_ID> --log-failed
+# or read the currently open GitHub Actions page
+```
+
+Extract:
+- Job name(s) that failed
+- Exact error message(s) with line numbers
+- Affected file path(s)
+
+### Step 2: Locate Affected Files
+
+```bash
+# Find the workflow file
+grep -n "on:" .github/workflows/*.yml
+cat .github/workflows/<FILENAME>.yml
+```
+
+### Step 3: Research Fix
+
+Use websearch to find the fix in official documentation:
+- yamllint docs: `https://yamllint.readthedocs.io/`
+- GitHub Actions docs: `https://docs.github.com/en/actions`
+- Action-specific release notes
+
+Only proceed if:
+- Official documentation confirms the fix
+- The fix is syntactic (no behavioral change)
+- There is exactly one valid solution
+
+### Step 4: Apply Fix via OpenCode CLI
+
+Construct a precise, constrained prompt:
+
+```bash
+opencode run --model ollama/qwen3-coder:cloud \
+  "[PRECISE FIX DESCRIPTION WITH EXACT BEFORE/AFTER. ONLY THIS CHANGE. NO OTHER MODIFICATIONS.]"
+```
+
+For the yamllint `rule:truthy` pattern on `on:` key:
+```bash
+opencode run --model ollama/qwen3-coder:cloud \
+  "In .github/workflows/<FILE>.yml, find the line containing only 'on:' \
+   (GitHub Actions event trigger, near top of file). \
+   Add '# yamllint disable-line rule:truthy' as an inline comment on that same line. \
+   Result: 'on: # yamllint disable-line rule:truthy'. \
+   Preserve all indentation. Modify only this line. No other changes."
+```
+
+### Step 5: Verify
+
+```bash
+# Verify with yamllint
+pip install yamllint -q
+yamllint -d '{extends: default}' .github/workflows/<FILE>.yml
+echo "Exit code: $?"
+```
+
+### Step 6: Commit
+
+```bash
+git add .github/workflows/<FILE>.yml
+git commit -m "fix(ci): resolve yamllint rule:truthy in <FILE>.yml
+
+Add inline yamllint disable-line comment on on: trigger key.
+Fix source: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy"
+git push
+```
+
+## Known Safe Fix Patterns
+
+See `.agents/skills/ci-autofix/references/fix-patterns.md` for all validated patterns.
+
+| Error | Safe to Auto-Fix | Fix |
+|---|---|---|
+| yamllint `rule:truthy` on `on:` | YES | Add `# yamllint disable-line rule:truthy` inline |
+| Deprecated action version (patch) | YES | Update to documented latest patch |
+| Missing `---` document start | YES | Add `---` at top of file |
+| Logic errors in scripts | NO | Escalate |
+| Semantic workflow changes | NO | Escalate |
+| Ambiguous exit codes | NO | Escalate |
+
+## Output Format
+
+After completing a fix, report:
+
+```
+## CI Autofix Report
+
+### Run
+- **Run ID**: <id>
+- **Failing Job**: <job name>
+- **Error**: <exact error message>
+
+### Analysis
+- **File**: <path>
+- **Root Cause**: <description>
+- **Fix Source**: <official documentation URL>
+- **Fix Confidence**: HIGH / MEDIUM / LOW
+
+### Action Taken
+- **Fix Applied**: <yes/no/escalated>
+- **Change**: <before> -> <after>
+- **Verification**: yamllint exit code 0 / FAILED
+
+### Commit
+- <commit hash> <commit message>
+```
+
+If escalating:
+```
+## CI Autofix: Escalation Required
+
+### Why Auto-Fix Was Not Applied
+- <reason: ambiguous / semantic / multiple options / no official doc>
+
+### Raw Error
+<error output>
+
+### Recommended Next Steps
+<suggestions for the user>
+```
+
+## Coordinates With
+
+- **github-action-editor**: For creating or restructuring workflows
+- **yaml-validation**: For deep YAML schema validation
+- **cicd-pipeline**: For pipeline design questions
+
+## Skills Used
+
+- `.agents/skills/ci-autofix` — Core skill with fix patterns and decision tree
+- `.agents/skills/cicd-pipeline` — Pipeline design context


### PR DESCRIPTION
## Summary

This PR adds a new `ci-autofix` agent skill and fixes the failing yamllint CI.

### New Skill: `ci-autofix`

A complete agent skill for detecting and auto-fixing failing CI pipelines using OpenCode CLI with Ollama Cloud. The skill follows a strict safety-first principle: it only applies fixes when the solution is **unambiguous and validated against official documentation**.

**Files added:**
- `.agents/skills/ci-autofix/SKILL.md` — Core skill definition with workflow, decision tree, and OpenCode CLI integration
- `.agents/skills/ci-autofix/references/fix-patterns.md` — Validated fix patterns with documentation sources (Pattern 001: yamllint rule:truthy)
- `.agents/skills/ci-autofix/evals/evals.json` — 4 evaluation scenarios including auto-fix, batch fix, escalation, and misplaced comment cases
- `.opencode/agents/ci-autofix.md` — OpenCode subagent definition with Ollama Cloud provider config, step-by-step process, and structured output format

### CI Fix: `version-propagation.yml`

The YAML Syntax Validation CI job was failing because `version-propagation.yml` had `on:` without a yamllint disable comment.

**Root cause:** yamllint interprets `on:` as a truthy boolean value per YAML 1.1 spec. This is a documented false positive for GitHub Actions workflows.

**Fix applied** (documented at https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy):
```yaml
# Before
on:

# After  
on: # yamllint disable-line rule:truthy
```

### Ollama Cloud Provider Config

The skill uses Ollama Cloud (not local) as documented at https://ollama.com/docs/integrations/opencode:
```json
{
  "provider": {
    "ollama": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "Ollama Cloud",
      "options": { "baseURL": "https://ollama.com/v1" },
      "models": { "qwen3-coder:cloud": { "name": "qwen3-coder:cloud" } }
    }
  }
}
```