### PR TITLE
fix(ci): replace unresolvable actions/checkout v4 SHA with v6.0.2

### DIFF
--- a/.github/workflows/sync-turso-skill.yml
+++ b/.github/workflows/sync-turso-skill.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Fetch latest Turso release and llms.txt
         run: |

--- a/.github/workflows/version-propagation.yml
+++ b/.github/workflows/version-propagation.yml
@@ -15,7 +15,7 @@ jobs:
   propagate-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b16db06985a3d4b3b86f0c0f870 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Problem\n\nThe actions/checkout SHA `11bd71901bbe5b16db06985a3d4b3b86f0c0f870` (v4.2.2) is no longer resolvable by the GitHub Actions runner, causing all **Version Propagation** workflow runs to fail:\n\n```\n##[error]Unable to resolve action `actions/checkout@11bd71901bbe5b16...`, unable to find version`\n```\n\n## Fix\n\nReplace with `de0fac2e` (v6.0.2) — the same SHA already proven working across all other workflows (ci-and-labels, security-scan, labeler, cleanup, yaml-lint, knowledge-cleanup).\n\n## Affected Files\n\n- `.github/workflows/version-propagation.yml`\n- `.github/workflows/sync-turso-skill.yml`