### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in skill file validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-16 - Path Traversal in Pathlib Join
+**Vulnerability:** Path traversal in `scripts/lib/eval_executors.py` where `skill_path / file_path` allowed absolute path injection.
+**Learning:** In Python's `pathlib`, the `/` operator returns the second operand if it's absolute, bypassing the base path.
+**Prevention:** Strip leading slashes from subpaths and validate with `.resolve()` and `.relative_to()` to enforce directory boundaries.

--- a/scripts/lib/eval_executors.py
+++ b/scripts/lib/eval_executors.py
@@ -88,9 +88,20 @@ def run_file_validation(
         )
     missing: list[str] = []
     found: list[str] = []
+    base_path = skill_path.resolve()
     for file_path in files:
-        full_path = skill_path / file_path
-        if not full_path.exists():
+        # Prevent path traversal by ensuring it stays within skill_path
+        # Remove leading slash to prevent joining as absolute path
+        safe_rel_path = str(file_path).lstrip('/')
+        full_path = (skill_path / safe_rel_path).resolve()
+
+        try:
+            full_path.relative_to(base_path)
+            path_escaped = False
+        except ValueError:
+            path_escaped = True
+
+        if path_escaped or not full_path.exists():
             missing.append(file_path)
         else:
             found.append(file_path)


### PR DESCRIPTION
🛡️ Severity: HIGH
💡 Vulnerability: Path traversal in `scripts/lib/eval_executors.py`
🎯 Impact: Malicious skill definitions could potentially verify existence of arbitrary files on the system by climbing out of their assigned directory.
🔧 Fix: Used `pathlib.Path.resolve()` and `relative_to()` to enforce directory boundaries and stripped leading slashes from subpaths.
✅ Verification: Created a test script verifying that absolute paths and '..' parent references are correctly rejected while valid relative paths still work. Verified with `scripts/run-evals.py --type structure`.

---
*PR created automatically by Jules for task [6048877649871176356](https://jules.google.com/task/6048877649871176356) started by @d-o-hub*