### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass in URL validation

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/utils.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils.py
@@ -89,7 +89,11 @@ def is_safe_url(url: str) -> bool:
             return False
         if parsed.scheme not in ("http", "https"):
             return False
-        hostname = parsed.netloc.split(":")[0]
+        # Use .hostname instead of .netloc to correctly handle credentials
+        # (e.g., http://user@localhost) and avoid SSRF bypasses.
+        hostname = parsed.hostname
+        if hostname is None:
+            return False
         if hostname.lower() in (
             "localhost",
             "localhost.localdomain",

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Path traversal in `scripts/lib/eval_executors.py` where `skill_path / file_path` allowed absolute path injection.
 **Learning:** In Python's `pathlib`, the `/` operator returns the second operand if it's absolute, bypassing the base path.
 **Prevention:** Strip leading slashes from subpaths and validate with `.resolve()` and `.relative_to()` to enforce directory boundaries.
+
+## 2026-04-16 - SSRF Bypass via Flawed Hostname Extraction
+**Vulnerability:** SSRF bypass in `.agents/skills/do-web-doc-resolver/scripts/utils.py` where `parsed.netloc.split(":")[0]` was used to extract the hostname.
+**Learning:** Using `netloc.split(":")` to extract a hostname fails when the URL contains user information (e.g., `http://user@127.0.0.1`), as it returns the username instead of the host.
+**Prevention:** Always use `urllib.parse.urlparse(url).hostname` to reliably extract the hostname for security validations and blacklisting.


### PR DESCRIPTION
### Analysis and Reasoning:
The `is_safe_url` function in `.agents/skills/do-web-doc-resolver/scripts/utils.py` was intended to prevent Server-Side Request Forgery (SSRF) by blacklisting internal IP ranges and hostnames like `localhost`. However, it extracted the hostname using `parsed.netloc.split(":")[0]`. 

According to RFCs, `netloc` can contain user information in the format `user:password@host:port`. By providing a URL like `http://bypass@127.0.0.1`, the previous logic would extract `bypass` as the hostname, which is not in the blacklist, thus allowing the request to proceed to `127.0.0.1`.

The fix switches to using `parsed.hostname`, which is specifically designed to extract the host portion of the URL, correctly ignoring any user information or port numbers.

### Changes:
- Modified `.agents/skills/do-web-doc-resolver/scripts/utils.py` to use `parsed.hostname`.
- Added a safety check to return `False` if `parsed.hostname` is `None`.
- Added a clarifying comment regarding the security reason for using `.hostname`.

### Verification:
- Created a reproduction script `repro_ssrf.py` which confirmed `http://bypass@127.0.0.1` was considered SAFE before the fix.
- Verified with `repro_ssrf_fixed.py` that the same URL is now correctly identified as UNSAFE.
- Ran the full test suite for the `do-web-doc-resolver` skill (`pytest tests/`) and all 177 non-live tests passed.
- Recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [146567325067208165](https://jules.google.com/task/146567325067208165) started by @d-o-hub*