### PR TITLE
feat(ci): add workflow to auto-resolve outdated bot comments

### DIFF
--- a/.github/workflows/resolve-outdated-comments.yml
+++ b/.github/workflows/resolve-outdated-comments.yml
@@ -1,0 +1,25 @@
+---
+name: Auto resolve outdated bot conversations
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  resolve-outdated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve outdated DeepSource threads
+        uses: Ardiannn08/resolve-outdated-comment@3b3cf4b2651a84fac2d6a94c2aeca9ac7c05ac5f  # v1.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filter-user: "deepsource-io[bot]"
+          mode: "resolve"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ Fix ALL pre-existing issues before completing. See `agents-docs/WORKFLOW.md#pre-
 After non-trivial work: run the `learn` skill or manually append non-obvious discoveries to the nearest relevant `AGENTS.md`. Capture only: hidden file relationships, surprising execution behavior, undocumented commands, fragile config, files that must change together. Never write: obvious facts, duplicates, verbose explanations. See `agents-docs/WORKFLOW.md#post-task-learning` for details.
 
 #### Recent Project-Wide Learnings
+- **GitHub Action SHA Pinning**: Always pin actions to full 40-character commit SHAs with version comments to ensure supply chain security (LESSON-016)
 - **Worktree Cleanup**: Scripts creating worktrees must register them in `CREATED_WORKTREES` and use the `trap cleanup EXIT ERR` pattern (LESSON-010)
 
 ### Context Discipline

--- a/agents-docs/LESSONS.md
+++ b/agents-docs/LESSONS.md
@@ -735,3 +735,25 @@ jobs:
 - REST API docs: POST /repos/{owner}/{repo}/labels requires issues:write
 
 ---
+
+### LESSON-016: GitHub Actions Security - SHA Pinning for Third-Party Actions
+
+**Issue**: Using floating tags or branch names (e.g., `@v1.3`) for GitHub Actions can introduce security risks if the tag is moved to a malicious commit or the branch is compromised.
+
+**Root Cause**: Git tags are mutable and can be reassigned. SHA-1 hashes are immutable and provide a deterministic way to reference a specific version of an action.
+
+**Solution**: Always pin GitHub Actions to a full 40-character commit SHA and add a comment with the version tag for readability (e.g., `uses: action/name@SHA # v1.3`).
+
+**Prevention**:
+- Use `git ls-remote --tags` to find the exact SHA behind a release tag before adding it to a workflow.
+- Review project-wide `AGENTS.md` for SHA pinning mandates.
+- Enable Dependabot to automatically update pinned SHAs when new versions are released.
+
+**Tags**: #security #github-actions #sha-pinning #supply-chain
+
+**Files Modified**:
+- `.github/workflows/resolve-outdated-comments.yml`
+
+**References**:
+- GitHub Security Best Practices: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+---


### PR DESCRIPTION
Create a new GitHub Action workflow that automatically resolves outdated conversations from deepsource-io[bot] on pull requests. The action is pinned to the v1.3 release SHA for security.

- Added .github/workflows/resolve-outdated-comments.yml
- Updated AGENTS.md and LESSONS.md with security learnings (LESSON-016)

---
*PR created automatically by Jules for task [14077842089738169274](https://jules.google.com/task/14077842089738169274) started by @d-o-hub*