### PR TITLE
🛡️ Sentinel: harden link validation against path traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** URL reconstruction in `normalize_url` and `fetch_llms_txt` in `.agents/skills/do-web-doc-resolver/scripts/utils.py` used `parsed.netloc`, which includes user credentials (e.g., `user:pass@host`).
 **Learning:** `parsed.netloc` preserves credentials and raw port strings. Using it to reconstruct URLs for further requests or cache keys can lead to credential leakage in logs/cache or SSRF bypasses if the host is misidentified.
 **Prevention:** Use a dedicated helper to reconstruct `netloc` from `parsed.hostname` and `parsed.port`, explicitly stripping credentials and normalizing default ports.
+
+## 2026-04-20 - Path Traversal in Bash Link Validation
+**Vulnerability:** Path traversal in `scripts/validate-links.sh` allowed checking existence of files outside the repository via absolute paths or `..` sequences in documentation links.
+**Learning:** Bash string prefix matching `[[ "$path" != "$base"* ]]` is vulnerable to partial directory name bypasses (e.g., `/app` matching `/app-secret`).
+**Prevention:** Reject absolute paths explicitly and use `realpath` to resolve links. Always append trailing slashes to both path and base when performing boundary checks: `[[ "$resolved_path/" != "$resolved_root/"* ]]`.

--- a/scripts/validate-links.sh
+++ b/scripts/validate-links.sh
@@ -100,30 +100,43 @@ check_link() {
     # Remove any anchor from the path (file.md#section -> file.md)
     local clean_path="${link_path%%#*}"
 
-    # Resolve the full path without subshells
-    local full_path
+    # Security check: Reject absolute paths (Path Traversal prevention)
     if [[ "$clean_path" == /* ]]; then
-        full_path="$clean_path"
-    else
-        # Quick check: does the path exist relative to skill_dir?
-        # This covers 99% of cases without needing realpath
-        full_path="$skill_dir/$clean_path"
+        echo -e "  ${RED}✗${NC} Security Error: Absolute path detected at line $line_num: \`${clean_path}'" >&2
+        echo -e "     Links must be relative to the skill directory or repository root." >&2
+        echo -e "     in: $skill_file" >&2
+        return 1
     fi
 
-    # Check if file or directory exists directly
-    if [[ -e "$full_path" || -L "$full_path" ]]; then
-        return 0
-    fi
+    # Resolve the full path
+    local full_path="$skill_dir/$clean_path"
 
-    # Only if direct check fails, try normalizing with realpath (if available)
-    # This handles complex relative paths like ../../
+    # Security check: Ensure the path is within REPO_ROOT (Path Traversal prevention)
     if [ -z "$HAS_REALPATH" ]; then
         if command -v realpath &> /dev/null; then HAS_REALPATH=1; else HAS_REALPATH=0; fi
     fi
 
     if [ "$HAS_REALPATH" -eq 1 ]; then
-        # realpath -m (mock mode) doesn't require path to exist
-        full_path=$(realpath -m "$full_path" 2>/dev/null)
+        # Normalize paths for reliable prefix checking
+        local resolved_path
+        resolved_path=$(realpath -m "$full_path" 2>/dev/null)
+        local resolved_root
+        resolved_root=$(realpath -m "$REPO_ROOT" 2>/dev/null)
+
+        # Ensure trailing slash for robust prefix matching
+        if [[ "$resolved_path/" != "$resolved_root/"* ]]; then
+            echo -e "  ${RED}✗${NC} Security Error: Path traversal detected at line $line_num: \`${clean_path}'" >&2
+            echo -e "     Link attempts to reference a file outside the repository boundary." >&2
+            echo -e "     in: $skill_file" >&2
+            return 1
+        fi
+
+        # Check if file or directory exists within the boundary
+        if [[ -e "$resolved_path" || -L "$resolved_path" ]]; then
+            return 0
+        fi
+    else
+        # Fallback if realpath not available: basic existence check
         if [[ -e "$full_path" || -L "$full_path" ]]; then
             return 0
         fi


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix path traversal in link validation

🚨 Severity: MEDIUM
💡 Vulnerability: The `scripts/validate-links.sh` script allowed documentation links to reference files outside the repository boundary via absolute paths or directory traversal sequences.
🎯 Impact: An attacker could use specially crafted `SKILL.md` files to probe for the existence of sensitive files on the host system (e.g., in a CI environment) during validation.
🔧 Fix: Enhanced `check_link` to explicitly reject absolute paths and use `realpath` for path normalization. Implemented a robust boundary check by ensuring the resolved path starts with the repository root (using trailing slashes to prevent partial name bypasses).
✅ Verification: Verified with test cases containing `/etc/passwd` and `../../../../etc/passwd` links, which are now correctly identified and blocked. Existing valid relative links continue to pass.

---
*PR created automatically by Jules for task [17755835543751745590](https://jules.google.com/task/17755835543751745590) started by @d-o-hub*