### PR TITLE
Enforce local commit message validation + AI helper

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,23 @@
+---
+description: Create a conventional commit
+---
+
+# Create a conventional commit
+
+Use this command to create a valid conventional commit.
+
+## Usage
+
+```bash
+./scripts/ai-commit.sh --type <type> [--scope <scope>] --subject <subject> [--body <body> ...]
+```
+
+## Rules
+
+1. **Type**: Must be one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+2. **Subject**: Max 72 characters, imperative mood, no period at the end.
+3. **Body**: Use multiple `--body` flags for multiple paragraphs. Lines are automatically wrapped at 100 characters.
+
+## Manual Commits
+
+If you commit manually, the `commit-msg` hook will validate your message. If it fails, use `git commit --amend` to fix it.

--- a/.gemini/COMMIT_GUIDELINES.md
+++ b/.gemini/COMMIT_GUIDELINES.md
@@ -1,0 +1,6 @@
+# Commit Instructions
+
+All commits must follow Conventional Commits.
+
+1. **Preferred**: Use `./scripts/ai-commit.sh --type <type> --subject <subject> --body <body>`
+2. **Manual**: Validated via `.githooks/commit-msg`. Fix with `git commit --amend` if rejected.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Git commit-msg hook to validate commit messages.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if ! "$REPO_ROOT/scripts/validate-commit-message.sh" "$1"; then
+    echo ""
+    echo "--------------------------------------------------------------------------------"
+    echo "COMMIT REJECTED: Invalid commit message format."
+    echo "Please follow Conventional Commits: type(scope): subject"
+    echo "See AGENTS.md or templates/commit-message.txt for examples."
+    echo ""
+    echo "To fix, you can amend your commit message:"
+    echo "  git commit --amend"
+    echo "--------------------------------------------------------------------------------"
+    exit 1
+fi

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Incomplete SSRF protection in `do-web-doc-resolver` where orchestrator and provider levels lacked initial URL validation.
 **Learning:** Relying on utility-level SSRF checks is insufficient if high-level entry points bypass them or if specialized tools (e.g., `docling`, `tesseract`) are called directly without validation.
 **Prevention:** Implement centralized SSRF validation at all entry points (orchestrators) and redundant checks at the provider level. Use `--` separators in subprocess calls to prevent argument injection from malicious URLs.
+
+## 2026-04-21 - Local Commit Message Validation
+**Requirement:** CI was catching commit message violations that should be caught locally.
+**Learning:** Relying on CI for format validation increases feedback loop time and results in broken builds.
+**Prevention:** Enforce commit message validation locally via `commit-msg` git hook. Provide `./scripts/ai-commit.sh` helper for agents to produce valid commits.

--- a/.opencode/commands/commit.md
+++ b/.opencode/commands/commit.md
@@ -7,7 +7,12 @@ commit and push
 
 ## Commit Message Structure
 
-Use this format for commits:
+Use `./scripts/ai-commit.sh` to ensure valid commits:
+```bash
+./scripts/ai-commit.sh --type <type> --subject <subject> --body <body>
+```
+
+Or follow this format for manual commits:
 ```
 type(scope): Brief description (50 chars max)
 

--- a/.qwen/COMMIT_GUIDELINES.md
+++ b/.qwen/COMMIT_GUIDELINES.md
@@ -1,0 +1,6 @@
+# Commit Instructions
+
+All commits must follow Conventional Commits.
+
+1. **Preferred**: Use `./scripts/ai-commit.sh --type <type> --subject <subject> --body <body>`
+2. **Manual**: Validated via `.githooks/commit-msg`. Fix with `git commit --amend` if rejected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,25 @@ See `agents-docs/VERSION.md` for full workflow details.
 - Title/Commit: `type(scope): description` (max `${MAX_PR_TITLE_LENGTH}` chars)
 - Branch per feature; One concern per PR; Never commit to `main`
 
+### Commit Workflow (Mandatory)
+
+1. **Use Helper (Preferred)**: Run `./scripts/ai-commit.sh --type <type> --subject <subject> --body <body>`
+2. **Manual Commits**: Validated via `.githooks/commit-msg` (requires `./scripts/install-git-hooks.sh`)
+3. **If Validation Fails**: Identify violation, then `git commit --amend` to fix message.
+
+**Valid Example:**
+```text
+feat(search): add fuzzy matching to improve discovery
+
+Users can now find documents even with typos. This uses the
+Levenshtein distance algorithm for better results.
+```
+
+**Invalid Example (Body line too long):**
+```text
+fix(auth): resolve login timeout issue for users on slow connections by increasing the default timeout from 5 to 30 seconds
+```
+
 ### Commit Type Mapping
 
 | Intent                        | Type     | Scope suggestion |

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 100],
+  },
 };

--- a/scripts/ai-commit.sh
+++ b/scripts/ai-commit.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Helper for AI agents to create valid conventional commits.
+# Usage: ./scripts/ai-commit.sh --type <type> [--scope <scope>] --subject <subject> [--body <body> ...]
+
+set -euo pipefail
+
+TYPE=""
+SCOPE=""
+SUBJECT=""
+BODIES=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --type)
+      TYPE="$2"
+      shift 2
+      ;;
+    --scope)
+      SCOPE="$2"
+      shift 2
+      ;;
+    --subject)
+      SUBJECT="$2"
+      shift 2
+      ;;
+    --body)
+      BODIES+=("$2")
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$TYPE" ] || [ -z "$SUBJECT" ]; then
+    echo "Usage: $0 --type <type> [--scope <scope>] --subject <subject> [--body <body> ...]"
+    exit 1
+fi
+
+if [ ${#SUBJECT} -gt 72 ]; then
+    echo "Error: Subject is too long (${#SUBJECT} > 72 chars)."
+    exit 1
+fi
+
+# Build message
+MSG="${TYPE}"
+if [ -n "$SCOPE" ]; then
+    MSG="${MSG}(${SCOPE})"
+fi
+MSG="${MSG}: ${SUBJECT}"
+
+# Add blank line and bodies
+if [ ${#BODIES[@]} -gt 0 ]; then
+    MSG="${MSG}\n"
+    for BODY in "${BODIES[@]}"; do
+        # Wrap body to 100 chars
+        WRAPPED_BODY=$(echo "$BODY" | fold -s -w 100)
+        MSG="${MSG}\n${WRAPPED_BODY}\n"
+    done
+fi
+
+# Create temp file
+TMP_MSG=$(mktemp)
+echo -e "$MSG" > "$TMP_MSG"
+
+# Validate
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if ! "$REPO_ROOT/scripts/validate-commit-message.sh" "$TMP_MSG"; then
+    echo "Commit message validation failed."
+    rm "$TMP_MSG"
+    exit 1
+fi
+
+# Commit
+git commit -F "$TMP_MSG"
+rm "$TMP_MSG"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Install git hooks from .githooks directory.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "Configuring git to use .githooks directory..."
+git config core.hooksPath .githooks
+
+echo "Ensuring hooks are executable..."
+chmod +x "$REPO_ROOT/.githooks/"*
+
+echo "Git hooks installed successfully."

--- a/scripts/validate-commit-message.sh
+++ b/scripts/validate-commit-message.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Validate a commit message using commitlint.
+# Usage: ./scripts/validate-commit-message.sh <commit-msg-file>
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="${1:-}"
+
+if [ -z "$COMMIT_MSG_FILE" ]; then
+    echo "Error: No commit message file specified."
+    echo "Usage: $0 <commit-msg-file>"
+    exit 1
+fi
+
+if [ ! -f "$COMMIT_MSG_FILE" ]; then
+    echo "Error: Commit message file not found: $COMMIT_MSG_FILE"
+    exit 1
+fi
+
+# Run commitlint
+if ! npx commitlint --edit "$COMMIT_MSG_FILE"; then
+    exit 1
+fi
+
+exit 0

--- a/scripts/validate-git-hooks.sh
+++ b/scripts/validate-git-hooks.sh
@@ -42,12 +42,14 @@ if [ -n "$GLOBAL_HOOKS_PATH" ]; then
 fi
 
 # Check if local hooks path is correctly set
-if [ -n "$LOCAL_HOOKS_PATH" ] && [ "$LOCAL_HOOKS_PATH" != ".git/hooks" ]; then
+if [ -n "$LOCAL_HOOKS_PATH" ] && [ "$LOCAL_HOOKS_PATH" != ".git/hooks" ] && [ "$LOCAL_HOOKS_PATH" != ".githooks" ]; then
     echo -e "${RED}✗ ERROR: Local hooks path is non-standard!${NC}"
     echo -e "   Local hooks path: ${YELLOW}$LOCAL_HOOKS_PATH${NC}"
     echo ""
     echo "To reset to standard path:"
     echo "    git config --local core.hooksPath .git/hooks"
+    echo "Or to use repository hooks:"
+    echo "    git config --local core.hooksPath .githooks"
     echo ""
     exit 1
 fi

--- a/templates/commit-message.txt
+++ b/templates/commit-message.txt
@@ -1,0 +1,11 @@
+feat(ui): add dark mode support
+
+The user can now toggle between light and dark themes in the settings panel.
+This change includes a new theme provider and updated CSS variables for all
+components to ensure consistent look and feel.
+
+- Added ThemeProvider to root
+- Updated tailwind.config.js with dark mode variants
+- Implemented toggle in SettingsDialog
+
+Closes #456

--- a/tests/test-commit-scripts.sh
+++ b/tests/test-commit-scripts.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Test script for commit validation and helper scripts.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VALIDATE_SCRIPT="$REPO_ROOT/scripts/validate-commit-message.sh"
+AI_COMMIT_SCRIPT="$REPO_ROOT/scripts/ai-commit.sh"
+
+echo "Running tests for commit scripts..."
+
+# Create a temporary directory for test files
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Test 1: Valid commit message
+echo "Test 1: Valid commit message..."
+cat <<EOF > "$TEST_DIR/valid_msg.txt"
+feat(core): add new feature
+
+This is a valid body.
+It has multiple lines.
+EOF
+"$VALIDATE_SCRIPT" "$TEST_DIR/valid_msg.txt"
+echo "✓ Test 1 passed"
+
+# Test 2: Invalid commit message (invalid type)
+echo "Test 2: Invalid commit message (invalid type)..."
+cat <<EOF > "$TEST_DIR/invalid_type.txt"
+invalidtype(core): add new feature
+EOF
+if "$VALIDATE_SCRIPT" "$TEST_DIR/invalid_type.txt" 2>/dev/null; then
+    echo "✗ Test 2 failed: Invalid type was accepted"
+    exit 1
+fi
+echo "✓ Test 2 passed"
+
+# Test 3: Invalid commit message (subject too long)
+echo "Test 3: Invalid commit message (subject too long)..."
+cat <<EOF > "$TEST_DIR/long_subject.txt"
+feat(core): $(printf 'a%.0s' {1..80})
+EOF
+if "$VALIDATE_SCRIPT" "$TEST_DIR/long_subject.txt" 2>/dev/null; then
+    echo "✗ Test 3 failed: Long subject was accepted"
+    exit 1
+fi
+echo "✓ Test 3 passed"
+
+# Test 4: Invalid commit message (body line too long)
+# commitlint default for body-max-line-length is usually 100
+echo "Test 4: Invalid commit message (body line too long)..."
+cat <<EOF > "$TEST_DIR/long_body.txt"
+feat(core): valid subject
+
+$(printf 'b%.0s' {1..120})
+EOF
+if "$VALIDATE_SCRIPT" "$TEST_DIR/long_body.txt" 2>/dev/null; then
+    echo "✗ Test 4 failed: Long body line was accepted"
+    exit 1
+fi
+echo "✓ Test 4 passed"
+
+# Test 5: AI commit script validation (subject too long)
+echo "Test 5: AI commit script validation (subject too long)..."
+LONG_SUBJECT=$(printf 'a%.0s' {1..80})
+if "$AI_COMMIT_SCRIPT" --type feat --subject "$LONG_SUBJECT" 2>/dev/null; then
+    echo "✗ Test 5 failed: AI commit script accepted long subject"
+    exit 1
+fi
+echo "✓ Test 5 passed"
+
+echo "All tests passed!"


### PR DESCRIPTION
This PR implements local commit message validation and provides an AI-friendly commit helper script.

Key changes:
1.  **Local Validation**: A new `commit-msg` git hook (located in `.githooks/`) uses `commitlint` to validate commit messages before they are finalized. This catches errors like invalid types or overlong lines early in the workflow.
2.  **AI Helper**: `scripts/ai-commit.sh` provides a structured way for AI agents to create valid conventional commits. It handles line wrapping for the body and enforces subject length limits.
3.  **Standardized Instructions**: Documentation has been updated across `AGENTS.md` and various agent-specific configuration directories (`.claude`, `.gemini`, `.jules`, `.opencode`, `.qwen`) to ensure consistent behavior across all AI entry points.
4.  **Health Checks**: `scripts/validate-git-hooks.sh` was updated to recognize `.githooks` as a valid configuration.
5.  **Validation**: A new test script `tests/test-commit-scripts.sh` verifies that the validation logic correctly identifies valid and invalid commit messages.

Fixes #199

---
*PR created automatically by Jules for task [1911030708093076827](https://jules.google.com/task/1911030708093076827) started by @d-o-hub*