### PR TITLE
🛡️ Sentinel: Fix insecure domain scoring in do-web-doc-resolver

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/utils.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils.py
@@ -202,11 +202,13 @@ def score_result(url: str | None, content: str) -> float:
     score = 0.5
     if url:
         try:
-            domain = urlparse(url).netloc.lower()
-            if any(domain.endswith(tld) for tld in [".edu", ".gov", ".org", ".rs", ".io"]):
+            # Use .hostname to avoid credential-based masquerading (e.g., github.com@evil.com)
+            parsed = urlparse(url)
+            domain = (parsed.hostname or "").lower()
+            if any(domain == tld[1:] or domain.endswith(tld) for tld in [".edu", ".gov", ".org", ".rs", ".io"]):
                 score += 0.2
             if any(
-                site in domain
+                domain == site or domain.endswith("." + site)
                 for site in ["github.com", "stackoverflow.com", "docs.rs", "mozilla.org"]
             ):
                 score += 0.2

--- a/.agents/skills/do-web-doc-resolver/tests/test_security_sentinel.py
+++ b/.agents/skills/do-web-doc-resolver/tests/test_security_sentinel.py
@@ -1,27 +1,37 @@
 import pytest
-from scripts.utils import is_safe_url, score_result
+from scripts.utils import score_result
 
 def test_score_result_masquerading():
     # evil.com masquerading as github.com using credentials
     url = "https://github.com@evil.com"
     score = score_result(url, "some content")
-    # If vulnerable, it gets +0.2 bonus, total 0.7
-    # If fixed, it stays at 0.5 (or lower if content is short)
-    # The default score is 0.5. "some content" is short, so -0.2. Total 0.3.
-    # If masquerading works: 0.3 + 0.2 = 0.5.
-    # If fixed: 0.3.
-    assert score < 0.5
+    # The default score is 0.5. "some content" is short (<50 words), so -0.2 penalty. Total 0.3.
+    # If vulnerable, github.com@evil.com netloc match gives +0.2 bonus. Total 0.5.
+    # If fixed, score remains 0.3.
+    assert pytest.approx(score) == 0.3
 
 def test_score_result_domain_matching():
     # mygithub.com should not match github.com
     url = "https://mygithub.com"
-    score = score_result(url, "some content " * 100) # long content to avoid length penalty
-    # long content (>500 words) gives +0.1. Default 0.5 + 0.1 = 0.6.
+    # long content (>500 words) gives +0.1 bonus. 0.5 + 0.1 = 0.6.
+    content = "word " * 600
+    score = score_result(url, content)
     # If vulnerable, "github.com" in "mygithub.com" is True -> 0.6 + 0.2 = 0.8.
     # If fixed, it should be 0.6.
-    assert score == 0.6
+    assert pytest.approx(score) == 0.6
 
-def test_is_safe_url_dns_failure():
-    # This is hard to test without mocking socket.getaddrinfo
-    # But I can check if it handles it gracefully if I can mock it
-    pass
+def test_score_result_legitimate_matching():
+    # github.com should match
+    url = "https://github.com/d-oit/do-web-doc-resolver"
+    content = "word " * 600
+    score = score_result(url, content)
+    # 0.5 (base) + 0.1 (length) + 0.2 (github) = 0.8
+    assert pytest.approx(score) == 0.8
+
+def test_score_result_subdomain_matching():
+    # api.github.com should match
+    url = "https://api.github.com"
+    content = "word " * 600
+    score = score_result(url, content)
+    # 0.5 (base) + 0.1 (length) + 0.2 (github) = 0.8
+    assert pytest.approx(score) == 0.8

--- a/.agents/skills/do-web-doc-resolver/tests/test_security_sentinel.py
+++ b/.agents/skills/do-web-doc-resolver/tests/test_security_sentinel.py
@@ -1,0 +1,27 @@
+import pytest
+from scripts.utils import is_safe_url, score_result
+
+def test_score_result_masquerading():
+    # evil.com masquerading as github.com using credentials
+    url = "https://github.com@evil.com"
+    score = score_result(url, "some content")
+    # If vulnerable, it gets +0.2 bonus, total 0.7
+    # If fixed, it stays at 0.5 (or lower if content is short)
+    # The default score is 0.5. "some content" is short, so -0.2. Total 0.3.
+    # If masquerading works: 0.3 + 0.2 = 0.5.
+    # If fixed: 0.3.
+    assert score < 0.5
+
+def test_score_result_domain_matching():
+    # mygithub.com should not match github.com
+    url = "https://mygithub.com"
+    score = score_result(url, "some content " * 100) # long content to avoid length penalty
+    # long content (>500 words) gives +0.1. Default 0.5 + 0.1 = 0.6.
+    # If vulnerable, "github.com" in "mygithub.com" is True -> 0.6 + 0.2 = 0.8.
+    # If fixed, it should be 0.6.
+    assert score == 0.6
+
+def test_is_safe_url_dns_failure():
+    # This is hard to test without mocking socket.getaddrinfo
+    # But I can check if it handles it gracefully if I can mock it
+    pass

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,13 @@
 **Vulnerability:** SSRF protection in `do-web-doc-resolver` used a manual blacklist of `BLOCKED_NETWORKS`, which could miss non-public IP ranges like CGNAT (100.64.0.0/10) or documentation/reserved ranges.
 **Learning:** Manual IP blacklists are brittle and incomplete. Using `ipaddress.ip_address(ip).is_global` provides a more robust, future-proof way to identify non-public IPs (including private, reserved, loopback, and IPv4-mapped IPv6).
 **Prevention:** Prefer `ip.is_global` (or `not ip.is_global` to block) for SSRF validation. Always restore `socket.getdefaulttimeout()` when temporarily overriding it to avoid side effects in other network operations.
+
+## 2026-04-24 - Trust Score Manipulation via Insecure URL Parsing
+**Vulnerability:** URL trust scoring in  used  and loose substring matching () to identify trusted sites.
+**Learning:**  includes user credentials (e.g., ), allowing attackers to masquerade as trusted domains. Furthermore,  operator matching allows spoofing via related domains (e.g., ).
+**Prevention:** Always use  for domain-based security decisions to strip credentials. Use strict exact matching or explicit subdomain checks () instead of loose substring searches.
+
+## 2026-04-24 - Trust Score Manipulation via Insecure URL Parsing
+**Vulnerability:** URL trust scoring in `do-web-doc-resolver/scripts/utils.py` used `urlparse(url).netloc` and loose substring matching (`site in domain`) to identify trusted sites.
+**Learning:** `urlparse().netloc` includes user credentials (e.g., `trusted.com@evil.com`), allowing attackers to masquerade as trusted domains. Furthermore, `in` operator matching allows spoofing via related domains (e.g., `notgithub.com`).
+**Prevention:** Always use `urlparse(url).hostname` for domain-based security decisions to strip credentials. Use strict exact matching or explicit subdomain checks (`domain.endswith("." + site)`) instead of loose substring searches.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,11 +39,6 @@
 **Prevention:** Prefer `ip.is_global` (or `not ip.is_global` to block) for SSRF validation. Always restore `socket.getdefaulttimeout()` when temporarily overriding it to avoid side effects in other network operations.
 
 ## 2026-04-24 - Trust Score Manipulation via Insecure URL Parsing
-**Vulnerability:** URL trust scoring in  used  and loose substring matching () to identify trusted sites.
-**Learning:**  includes user credentials (e.g., ), allowing attackers to masquerade as trusted domains. Furthermore,  operator matching allows spoofing via related domains (e.g., ).
-**Prevention:** Always use  for domain-based security decisions to strip credentials. Use strict exact matching or explicit subdomain checks () instead of loose substring searches.
-
-## 2026-04-24 - Trust Score Manipulation via Insecure URL Parsing
 **Vulnerability:** URL trust scoring in `do-web-doc-resolver/scripts/utils.py` used `urlparse(url).netloc` and loose substring matching (`site in domain`) to identify trusted sites.
 **Learning:** `urlparse().netloc` includes user credentials (e.g., `trusted.com@evil.com`), allowing attackers to masquerade as trusted domains. Furthermore, `in` operator matching allows spoofing via related domains (e.g., `notgithub.com`).
 **Prevention:** Always use `urlparse(url).hostname` for domain-based security decisions to strip credentials. Use strict exact matching or explicit subdomain checks (`domain.endswith("." + site)`) instead of loose substring searches.


### PR DESCRIPTION
🛡️ Sentinel: MEDIUM Fix insecure domain scoring

🚨 Severity: MEDIUM
💡 Vulnerability: Trust score manipulation via insecure URL parsing.
🎯 Impact: Malicious or masquerading domains could receive an artificial trust score boost, potentially leading the agent to prioritize untrusted content.
🔧 Fix: Switched from `.netloc` to `.hostname` and implemented strict domain/subdomain matching.
✅ Verification: Verified with custom reproduction scripts confirming that `github.com@evil.com` and `mygithub.com` no longer receive score boosts, while `github.com` and `api.github.com` still do. Ran full quality gate.

---
*PR created automatically by Jules for task [16209545179458219426](https://jules.google.com/task/16209545179458219426) started by @d-o-hub*