### PR TITLE
⚡ Bolt: optimize validate-links.sh performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-05-22 - [Optimizing Bash cache keys and hash extraction]
 **Learning:** Significant performance gains in Bash scripts (up to 350x for string manipulation) can be achieved by replacing external utility pipes (`tr`, `cut`) and subshells (`$(cat ...)`) with native Bash parameter expansion and built-ins (`read`). In `lint_cache.sh`, replacing `echo | tr` with `${file//[\/\. ]/_}` and `cat` with `read` eliminated hundreds of subshells during quality gate execution.
 **Action:** Always prefer `${var//pattern/string}` for character replacement and `read -r var < file` for reading small config/cache files over `tr`, `sed`, or `cat` subshells.
+
+## 2026-05-23 - [AWK-to-Bash Streaming Optimization]
+**Learning:** For scripts that must process thousands of lines in Bash (e.g., Markdown validation), using `awk` to pre-filter and format only relevant lines into a colon-delimited stream (`LINE_NUM:STATE:CONTENT`) before piping to a `while read` loop can reduce execution time by ~50%. This avoids the high overhead of Bash's line-by-line processing for thousands of irrelevant lines while preserving complex validation logic in Bash.
+**Action:** Use `awk` to stream a "sparse" version of a large file to Bash when the validation logic is too complex for pure `awk` but the number of relevant lines is small.

--- a/scripts/validate-links.sh
+++ b/scripts/validate-links.sh
@@ -222,9 +222,10 @@ process_skill_file() {
     local file_format_errors=0
     local in_references=0
 
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        line_num=$((line_num + 1))
-
+    # Performance optimization: Use awk to pre-filter only relevant lines
+    # This reduces Bash loop iterations by ~90% for large files.
+    # Format: line_num:in_references:line_content
+    while IFS=: read -r line_num in_references line; do
         # Track if we're in the References section
         # State transitions: out -> in when see "## References", in -> out when see any other "##"
         if is_references_header "$line"; then
@@ -304,7 +305,13 @@ process_skill_file() {
             BROKEN_COUNT=$((BROKEN_COUNT + 1))
             file_broken=1
         fi
-    done < "$skill_file"
+    done < <(awk -v in_ref=0 '
+        /^##[[:space:]]+[Rr]eferences/ { in_ref = 1; print NR ":" in_ref ":" $0; next }
+        /^##[[:space:]]+/ { in_ref = 0; print NR ":" in_ref ":" $0; next }
+        /\[[^]]+\]\([^)]+\)/ || /`(references?\/|docs\/)[^`]+`/ || /@references?/ || (in_ref && /^- /) {
+            print NR ":" in_ref ":" $0
+        }
+    ' "$skill_file")
 
     if [[ $file_broken -eq 0 && $file_format_errors -eq 0 ]]; then
         # Performance optimization: Use Bash parameter expansion instead of basename


### PR DESCRIPTION
⚡ Bolt: Optimize link validation performance

💡 What: Refactored `scripts/validate-links.sh` to use an `awk` pre-filter that streams only relevant lines (headers, links, and reference entries) to the main Bash loop.

🎯 Why: The previous implementation iterated over every single line of every `SKILL.md` file in Bash (~6500 lines total). Since most lines in these files are narrative text without links, the shell was spending significant time on unnecessary string processing.

📊 Impact: 
- Reduces execution time by ~50% (benchmarked from ~0.86s to ~0.44s on 47 files).
- Reduces Bash loop iterations by >90%.

🔬 Measurement:
- Established baseline with `time ./scripts/validate-links.sh` (avg 0.86s).
- Verified optimized version with `time ./scripts/validate-links.sh` (avg 0.44s).
- Verified correctness by manually introducing broken links and verifying detection at correct line numbers.
- Verified repository health with `./scripts/quality_gate.sh`.

---
*PR created automatically by Jules for task [13709193661453430097](https://jules.google.com/task/13709193661453430097) started by @d-o-hub*