### PR TITLE
🧹 Refactor: move unused runtime import to TYPE_CHECKING in eval_types.py

### DIFF
--- a/scripts/lib/eval_types.py
+++ b/scripts/lib/eval_types.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class EvalType(Enum):
     """Types of evaluations that can be performed."""
+
     STRUCTURE = "structure"
     COMMAND = "command"
     FILE_VALIDATION = "file_validation"
@@ -16,6 +20,7 @@ class EvalType(Enum):
 
 class EvalStatus(Enum):
     """Status of an individual eval scenario."""
+
     PASS = "PASS"
     FAIL = "FAIL"
     SKIP = "SKIP"
@@ -25,6 +30,7 @@ class EvalStatus(Enum):
 @dataclass
 class EvalResult:
     """Result of a single eval scenario."""
+
     eval_id: int
     status: EvalStatus
     message: str = ""
@@ -35,6 +41,7 @@ class EvalResult:
 @dataclass
 class SkillEvalResult:
     """Result of evaluating a single skill."""
+
     skill_name: str
     skill_path: Path
     status: EvalStatus
@@ -49,6 +56,7 @@ class SkillEvalResult:
 @dataclass
 class EvalReport:
     """Overall evaluation report."""
+
     total_skills: int = 0
     skills_passed: int = 0
     skills_failed: int = 0


### PR DESCRIPTION
This PR addresses a code health issue in `scripts/lib/eval_types.py` where the `pathlib.Path` import was reported as unused at runtime.

🎯 **What:** Relocated `from pathlib import Path` to an `if TYPE_CHECKING:` block and added `from typing import TYPE_CHECKING`.
💡 **Why:** Since the file uses `from __future__ import annotations`, the `Path` class is only needed for static type checking and not at runtime. Moving it reduces runtime overhead and satisfies linting checks (e.g., `ruff` rule `TCH003`).
✅ **Verification:**
- Verified with `ruff check` (no F401 or TCH003 errors).
- Verified with `black --check`.
- Confirmed that `scripts/run-evals.py` (which depends on this module) still functions correctly.
✨ **Result:** Improved maintainability and performance by optimizing imports without breaking type safety or functionality.

---
*PR created automatically by Jules for task [18426465833148259567](https://jules.google.com/task/18426465833148259567) started by @d-o-hub*