### PR TITLE
🧹 Remove unused 'annotations' import in evaluation scripts

### DIFF
--- a/get_comments.sh
+++ b/get_comments.sh
@@ -1,0 +1,1 @@
+gh pr view --comments

--- a/get_comments.sh
+++ b/get_comments.sh
@@ -1,1 +1,0 @@
-gh pr view --comments

--- a/scripts/lib/eval_executors.py
+++ b/scripts/lib/eval_executors.py
@@ -1,6 +1,6 @@
 """Execution logic for command and file validation evals."""
 
-from __future__ import annotations
+
 
 import subprocess
 import sys

--- a/scripts/lib/eval_types.py
+++ b/scripts/lib/eval_types.py
@@ -1,6 +1,6 @@
 """Shared types and data classes for the evaluation runner."""
 
-from __future__ import annotations
+
 
 from dataclasses import dataclass, field
 from enum import Enum

--- a/scripts/lib/eval_validators.py
+++ b/scripts/lib/eval_validators.py
@@ -1,6 +1,6 @@
 """Validation logic for eval structure and format."""
 
-from __future__ import annotations
+
 
 import json
 from pathlib import Path

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -10,7 +10,7 @@ Usage:
     python3 scripts/run-evals.py --verbose --format json
 """
 
-from __future__ import annotations
+
 
 import argparse
 import json


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` import from evaluation scripts in the `scripts/lib` directory and `scripts/run-evals.py`.

💡 **Why:** Removes unused imports, which is a safe, single-line change with no side effects. This improves maintainability by removing code that isn't doing anything.

✅ **Verification:** Ran `scripts/run-evals.py` to ensure evaluations still function without runtime errors, and ran `scripts/quality_gate.sh` to ensure pre-commit steps pass. Checked manual loading of files too.

✨ **Result:** Cleaned up unused imports across all evaluation-related python scripts without breaking functionality.

---
*PR created automatically by Jules for task [5078023944468413617](https://jules.google.com/task/5078023944468413617) started by @d-o-hub*