### PR TITLE
🧹 [code health] prevent false positive unused import

### DIFF
--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -17,6 +17,7 @@ import json
 import sys
 from pathlib import Path
 
+# Note: run_command_check is used in run_eval_case, do not remove as an "unused import".
 from lib.eval_executors import run_command_check, run_file_validation
 from lib.eval_types import EvalReport, EvalResult, EvalStatus, EvalType, SkillEvalResult
 from lib.eval_validators import load_evals_file, run_structure_check, validate_evals_format


### PR DESCRIPTION
🧹 Code Health Improvement: Prevent false positive on unused import

🎯 **What:** Added an inline comment documenting that `run_command_check` is actively used in `scripts/run-evals.py` and is not an unused import.
💡 **Why:** To prevent future developers or automated tools from mistakenly removing the import, which would break the script with a `NameError` during command-based evaluations on line 39.
✅ **Verification:** Verified by attempting to remove the import (which crashed `scripts/run-evals.py` locally), and testing the fix ensuring evaluations passed successfully. Also passed all pre-commit hooks via `scripts/quality_gate.sh`.
✨ **Result:** The codebase is now more robust against breaking changes caused by incorrect "unused import" detection.

---
*PR created automatically by Jules for task [17472044546325042513](https://jules.google.com/task/17472044546325042513) started by @d-o-hub*