### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF fail-open in do-web-doc-resolver

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/utils.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils.py
@@ -145,12 +145,15 @@ def is_safe_url(url: str) -> bool:
             try:
                 socket.setdefaulttimeout(5)
                 infos = socket.getaddrinfo(hostname, None)
+                if not infos:
+                    return False
                 for _family, _socktype, _proto, _canonname, sockaddr in infos:
                     ip = ipaddress.ip_address(sockaddr[0])
                     if not ip.is_global:
                         return False
             except Exception:
-                pass
+                # If DNS resolution fails, fail-closed for security
+                return False
             finally:
                 socket.setdefaulttimeout(orig_timeout)
         return True

--- a/.agents/skills/do-web-doc-resolver/tests/test_security_sentinel.py
+++ b/.agents/skills/do-web-doc-resolver/tests/test_security_sentinel.py
@@ -28,6 +28,24 @@ def test_score_result_legitimate_matching():
     # 0.5 (base) + 0.1 (length) + 0.2 (github) = 0.8
     assert pytest.approx(score) == 0.8
 
+from scripts.utils import is_safe_url
+
+def test_is_safe_url_rejects_non_resolvable_hostnames():
+    # Test that hostnames that do not resolve are rejected (fail-closed)
+    # Using a .local or other TLD that definitely won't resolve in this environment
+    assert is_safe_url("https://definitely-does-not-exist.invalid-tld") is False
+
+def test_is_safe_url_allows_standard_public_url():
+    # Ensure it still works for legitimate public URLs
+    # github.com is highly likely to resolve and be global
+    assert is_safe_url("https://github.com/d-oit/do-web-doc-resolver") is True
+
+def test_is_safe_url_rejects_private_ips():
+    assert is_safe_url("http://192.168.1.1") is False
+    assert is_safe_url("http://10.0.0.1") is False
+    assert is_safe_url("http://127.0.0.1") is False
+    assert is_safe_url("http://localhost") is False
+
 def test_score_result_subdomain_matching():
     # api.github.com should match
     url = "https://api.github.com"

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 *   **Vulnerability**: The `do-web-doc-resolver` used `subprocess.run` with unsanitized URLs for `docling` and `ocr` providers, leaving them vulnerable to command injection payloads.
 *   **Fix**: Implemented `is_shell_safe_url` in `utils.py` and updated the providers to check and block shell-dangerous characters in the URL string prior to calling `subprocess.run()`.
 *   **Testing**: Added `tests/test_shell_safety.py` to ensure defense-in-depth against malicious URLs, including validating safe characters (`&`, `;`) and rejecting invalid ones (`|`, `<`, `>`, etc).
+
+## 2026-04-28 - Fail-closed SSRF Protection
+**Vulnerability:** The `is_safe_url` helper used a fail-open approach where DNS resolution failures or empty results would allow the URL to pass validation.
+**Learning:** Security validation functions must explicitly handle errors by denying access (fail-closed) rather than ignoring them.
+**Prevention:** Always implement explicit exception handling in safety-critical code that defaults to `False` or `AccessDenied`.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `is_safe_url` function in `do-web-doc-resolver` was fail-open on DNS resolution errors.
🎯 Impact: Potential SSRF bypass if DNS resolution fails or is manipulated.
🔧 Fix: Implemented fail-closed logic in `is_safe_url` and added comprehensive tests.
✅ Verification: Verified with `tests/test_security_sentinel.py` and `scripts/quality_gate.sh`.

---
*PR created automatically by Jules for task [1912549321082783286](https://jules.google.com/task/1912549321082783286) started by @d-o-hub*