### PR TITLE
feat(security): add explicit agent permission boundaries

### DIFF
--- a/.claude/PERMISSIONS.md
+++ b/.claude/PERMISSIONS.md
@@ -1,0 +1,25 @@
+# Claude Code — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write all files within the workspace.
+- Run `npm`, `cargo`, `git` commands.
+- Create branches, commits, and pull requests.
+- Read non-secret environment variables.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Execute network requests outside of explicitly listed domains.
+- Install global packages (`npm install -g`, `cargo install` to system).
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.
+
+## MCP POLICY
+- Only MCPs listed in `.claude/settings.json` are permitted.
+- Untrusted/community MCPs: NEVER add without explicit human approval.

--- a/.cursor/PERMISSIONS.md
+++ b/.cursor/PERMISSIONS.md
@@ -1,0 +1,19 @@
+# Cursor — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write files within the workspace.
+- Index codebase for context.
+- Use built-in terminal for commands.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Install global packages.
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.

--- a/.gemini/PERMISSIONS.md
+++ b/.gemini/PERMISSIONS.md
@@ -1,0 +1,24 @@
+# Gemini CLI — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write files within the workspace.
+- Execute shell commands as needed for task completion.
+- Access MCP tools configured in `settings.json`.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Execute network requests outside of explicitly listed domains.
+- Install global packages.
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.
+
+## MCP POLICY
+- Only MCPs listed in `.gemini/settings.json` are permitted.
+- Untrusted/community MCPs: NEVER add without explicit human approval.

--- a/.jules/PERMISSIONS.md
+++ b/.jules/PERMISSIONS.md
@@ -1,0 +1,21 @@
+# Jules/Codex — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write all files within the workspace.
+- Execute shell commands for testing and verification.
+- Create branches, commits, and pull requests.
+- Access cloud-based tools and services as configured.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Install global packages.
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.
+- When in doubt: stop and ask via a GitHub comment, don't proceed.

--- a/.opencode/PERMISSIONS.md
+++ b/.opencode/PERMISSIONS.md
@@ -1,0 +1,20 @@
+# OpenCode — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write all files within the workspace.
+- Execute shell commands and git operations.
+- Create branches, commits, and pull requests.
+- Read non-secret environment variables.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Install global packages.
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.

--- a/.qwen/PERMISSIONS.md
+++ b/.qwen/PERMISSIONS.md
@@ -1,0 +1,19 @@
+# Qwen Code — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write files within the workspace.
+- Execute shell commands as needed for task completion.
+- Access skills in `.qwen/skills/`.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Install global packages.
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.

--- a/.windsurf/PERMISSIONS.md
+++ b/.windsurf/PERMISSIONS.md
@@ -1,0 +1,19 @@
+# Windsurf — Permission Boundaries
+
+## Motivation
+Permission boundaries are the most important measure against AI-Agent catastrophes.
+- **Kiro incident**: 13-hour outage due to no permission boundaries and no review gate.
+- **Grigorev incident**: Production database destroyed by an agent with unconstrained write access.
+Reference: [Böttger's AI-Agent Catastrophes]
+
+## ALLOWED
+- Read and write files within the workspace.
+- Access editor-scoped features and terminal.
+- Use skills in `.windsurf/skills/`.
+
+## NEVER ALLOWED
+- Push directly to `main` or `release/*` branches.
+- Access, read, or log `*_API_KEY`, `*_SECRET`, `*_TOKEN` environment variables.
+- Install global packages.
+- Modify `.github/` workflow files without human review.
+- Access files outside the workspace root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,15 @@ Do not invent new types. Do not skip linting.
 - No secrets in commits (use `.env`); Pin Actions to SHA (with `# vX.Y` comment)
 - No untrusted MCPs; Report vulnerabilities via Private Advisories
 
+## Permission Boundaries (All Agents)
+
+- **Never** commit to `main` directly
+- **Never** read or reproduce secrets, tokens, or API keys
+- **Never** modify `.github/workflows/` without human review step
+- **Never** install global tooling
+- **Never** access resources outside the git workspace root
+- When in doubt: stop and ask via a GitHub comment, don't proceed
+
 ## Agent Guidance
 
 - **Plan**: Produce written plan, wait for confirmation for non-trivial tasks.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A unified harness for AI coding agents that provides consistent workflows across
 - ✓ **Multi-Agent Support**: Works with 6+ AI coding tools simultaneously
 - ✓ **Skills System**: Reusable knowledge modules in canonical location
 - ✓ **Quality Gates**: Automatic lint, test, format before commits
+- ✓ **Permission Boundaries**: Explicit per-agent ALLOWED/NEVER ALLOWED documentation
 - ✓ **Context Discipline**: Prevents context rot with sub-agents and hooks
 - ✓ **Dependabot Integration**: Automated security and version updates
 


### PR DESCRIPTION
Add explicit agent permission boundaries to each agent config directory and AGENTS.md to prevent AI-agent catastrophes. Motivated by Böttger's Kiro and Grigorev incidents.

Fixes #233

---
*PR created automatically by Jules for task [10915011831187248039](https://jules.google.com/task/10915011831187248039) started by @d-o-hub*