### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in evaluation framework

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@
 **Vulnerability:** The `is_safe_url` helper used a fail-open approach where DNS resolution failures or empty results would allow the URL to pass validation.
 **Learning:** Security validation functions must explicitly handle errors by denying access (fail-closed) rather than ignoring them.
 **Prevention:** Always implement explicit exception handling in safety-critical code that defaults to `False` or `AccessDenied`.
+
+## 2026-04-29 - Path Traversal in Evaluation Framework
+**Vulnerability:** The evaluation runner (`scripts/run-evals.py`) and its executors allowed path traversal via the `--skill` argument and `files` definitions in `evals.json`, potentially leading to arbitrary code execution if a malicious skill was loaded.
+**Learning:** Even internal tooling should enforce strict path boundaries. Relying on simple sanitization (like stripping leading slashes) is insufficient compared to explicit rejection of traversal sequences and absolute paths.
+**Prevention:** Use `Path.is_absolute()` and check for `..` substrings before joining paths in tools that handle user-provided or data-driven file paths.

--- a/scripts/lib/eval_executors.py
+++ b/scripts/lib/eval_executors.py
@@ -91,9 +91,13 @@ def run_file_validation(
     base_path = skill_path.resolve()
     for file_path in files:
         # Prevent path traversal by ensuring it stays within skill_path
-        # Remove leading slash to prevent joining as absolute path
-        safe_rel_path = str(file_path).lstrip('/')
-        full_path = (skill_path / safe_rel_path).resolve()
+        # Rejects absolute paths and traversal sequences explicitly
+        fpath = Path(file_path)
+        if ".." in str(file_path) or fpath.is_absolute():
+            missing.append(file_path)
+            continue
+
+        full_path = (skill_path / file_path).resolve()
 
         try:
             full_path.relative_to(base_path)

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -100,6 +100,10 @@ def evaluate_skill(
 def discover_skills(skills_dir: Path, specific_skill: str | None = None) -> list[Path]:
     """Discover all skills with evals/evals.json files."""
     if specific_skill:
+        # Prevent path traversal
+        skill_path = Path(specific_skill)
+        if ".." in specific_skill or skill_path.is_absolute():
+            return []
         skill_path = skills_dir / specific_skill
         evals_path = skill_path / "evals" / "evals.json"
         if skill_path.is_dir() and evals_path.exists():

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -132,3 +132,14 @@ def test_generate_text_report_with_skips():
     assert "Skipped: 1" in output
     assert "[PASS] skip-skill" in output
     assert "[SKIP] Eval #2: Missing tool" in output
+
+def test_discover_skills_traversal():
+    """Test that discover_skills rejects path traversal payloads."""
+    skills_dir = Path("/app/.agents/skills")
+
+    # Relative traversal
+    assert run_evals.discover_skills(skills_dir, "../../../tmp/exploit") == []
+    assert run_evals.discover_skills(skills_dir, "skill/../../etc") == []
+
+    # Absolute path
+    assert run_evals.discover_skills(skills_dir, "/etc/passwd") == []


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal in `scripts/run-evals.py` and `scripts/lib/eval_executors.py`. The evaluation framework previously allowed loading skills from arbitrary locations on the filesystem and validating existence of files outside the skill directory.
🎯 Impact: If an attacker could influence the skill name argument or provide a malicious `evals.json`, they might be able to trigger execution of arbitrary scripts (e.g., via `check_structure.py`) or leak file existence information.
🔧 Fix: Implemented strict path boundary enforcement. The framework now explicitly rejects any skill path or file reference that contains `..` or is an absolute path.
✅ Verification: Added unit tests in `tests/test_run_evals.py` covering relative and absolute traversal attempts. Manually verified that traversal payloads are blocked and no longer trigger script execution.

---
*PR created automatically by Jules for task [11475902408505975187](https://jules.google.com/task/11475902408505975187) started by @d-o-hub*