### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix shell arithmetic injection in skill validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@
 **Vulnerability:** The `is_safe_url` helper used a fail-open approach where DNS resolution failures or empty results would allow the URL to pass validation.
 **Learning:** Security validation functions must explicitly handle errors by denying access (fail-closed) rather than ignoring them.
 **Prevention:** Always implement explicit exception handling in safety-critical code that defaults to `False` or `AccessDenied`.
+
+## 2026-05-02 - Shell Arithmetic Injection in Validation Logic
+**Vulnerability:** Shell arithmetic expansion `$((...))` with unvalidated variables derived from `SKILL.md` frontmatter allowed arbitrary command execution during skill validation.
+**Learning:** Bash evaluates variables within arithmetic contexts (`$(( ))` and `(( ))`) as expressions. If these variables contain command substitution or other shell constructs, they are executed.
+**Prevention:** Strictly validate that all variables used in shell arithmetic contexts are numeric (e.g., using `[[ "$var" =~ ^[0-9]+$ ]]`) before evaluation.

--- a/scripts/lib/skill-validation.sh
+++ b/scripts/lib/skill-validation.sh
@@ -93,6 +93,13 @@ validate_skill_file() {
             local s_rest="${template_version#*.}"
             local s_minor="${s_rest%%.*}"
 
+            # Security: Validate numeric components to prevent shell arithmetic injection
+            if [[ ! "$c_major" =~ ^[0-9]+$ ]] || [[ ! "$c_minor" =~ ^[0-9]+$ ]] || \
+               [[ ! "$s_major" =~ ^[0-9]+$ ]] || [[ ! "$s_minor" =~ ^[0-9]+$ ]]; then
+                # If malformed, use safe defaults to avoid injection in $(( ))
+                c_major=0; c_minor=0; s_major=0; s_minor=0
+            fi
+
             if [[ "$s_major" -lt "$c_major" ]] || \
                { [[ "$s_major" -eq "$c_major" ]] && [[ $((c_minor - s_minor)) -gt 1 ]]; }; then
                 echo -e "  ${YELLOW}⚠${NC} $skill_name: template_version $template_version is >1 minor behind current $current_version" >&2


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Shell Arithmetic Expression Injection
🎯 Impact: Arbitrary command execution when validating malicious `SKILL.md` files. This could be exploited by a malicious actor submitting a PR with a compromised skill definition.
🔧 Fix: Implemented strict numeric validation (`[[ "$var" =~ ^[0-9]+$ ]]`) for all variables used in shell arithmetic expansion within `scripts/lib/skill-validation.sh`. Added safe defaults (0) if validation fails.
✅ Verification: Created a reproduction `SKILL.md` with a command execution payload and confirmed it no longer executes commands. Ran `./scripts/quality_gate.sh` to ensure no regressions.

---
*PR created automatically by Jules for task [8141848996969380335](https://jules.google.com/task/8141848996969380335) started by @d-o-hub*