### PR TITLE
🧹 cleanup unused imports and refactor to standard imports in tests

### DIFF
--- a/tests/test_eval_executors.py
+++ b/tests/test_eval_executors.py
@@ -1,17 +1,12 @@
 import sys
-import importlib.util
 from pathlib import Path
-import pytest
 
 # Add scripts directory to path for internal imports
 REPO_ROOT = Path(__file__).parent.parent
 scripts_dir = REPO_ROOT / "scripts"
 sys.path.append(str(scripts_dir))
 
-# Import eval_executors using importlib
-spec = importlib.util.spec_from_file_location("eval_executors", scripts_dir / "lib" / "eval_executors.py")
-eval_executors = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(eval_executors)
+from lib import eval_executors
 
 
 def test_run_command_check_no_scripts_dir(tmp_path):

--- a/tests/test_eval_validators.py
+++ b/tests/test_eval_validators.py
@@ -1,17 +1,12 @@
 import sys
-import importlib.util
 from pathlib import Path
-import pytest
 
 # Add scripts directory to path for internal imports
 REPO_ROOT = Path(__file__).parent.parent
 scripts_dir = REPO_ROOT / "scripts"
 sys.path.append(str(scripts_dir))
 
-# Import eval_validators using importlib
-spec = importlib.util.spec_from_file_location("eval_validators", scripts_dir / "lib" / "eval_validators.py")
-eval_validators = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(eval_validators)
+from lib import eval_validators
 
 validate_evals_format = eval_validators.validate_evals_format
 

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1,7 +1,6 @@
 import sys
 import importlib.util
 from pathlib import Path
-import pytest
 
 # Add scripts directory to path for internal imports
 REPO_ROOT = Path(__file__).parent.parent


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed unused `importlib.util` and `pytest` imports in `tests/test_eval_executors.py`, `tests/test_eval_validators.py`, and `tests/test_run_evals.py`.
- Refactored `tests/test_eval_executors.py` and `tests/test_eval_validators.py` to use standard static imports for modules in `scripts/lib/` instead of dynamic `importlib` loading.

💡 **Why:** How this improves maintainability
- Reduces boilerplate and improves readability by using standard Python import patterns.
- Eliminates dead code (unused imports) identified by AST analysis and linters.
- Consistent import patterns across the test suite.

✅ **Verification:** How you confirmed the change is safe
- Ran `pytest tests/` and all 36 tests passed successfully.
- Ran `ruff check` on the modified files to ensure all unused imports were correctly identified and removed.
- Verified that `pytest` was not used in any of the modified files before removing the import.
- Ran the project's quality gate script.

✨ **Result:** The improvement achieved
- Cleaner test files with only necessary imports.
- More idiomatic module loading for the project's internal library.

---
*PR created automatically by Jules for task [11060973723826290887](https://jules.google.com/task/11060973723826290887) started by @d-o-hub*