### PR TITLE
Implement proper code block parsing

### DIFF
--- a/scripts/discover-commands.sh
+++ b/scripts/discover-commands.sh
@@ -31,6 +31,8 @@ find "$REPO_ROOT" -type f -name "*.md" \
         valid_types["sh"] = 1
         valid_types["shell"] = 1
         valid_types["console"] = 1
+        valid_types["zsh"] = 1
+        valid_types["fish"] = 1
     }
     { sub(/\r$/, "") }
     FNR == 1 { in_block = 0; btype = "" }
@@ -40,9 +42,11 @@ find "$REPO_ROOT" -type f -name "*.md" \
             btype = ""
         } else {
             in_block = 1
-            # Extract language type from after the backticks
-            if (match(substr($0, index($0, "```") + 3), /^[a-zA-Z]+/)) {
-                btype = substr($0, index($0, "```") + 3, RLENGTH)
+            # Extract language type from after the backticks, allowing for spaces
+            rest = substr($0, index($0, "```") + 3)
+            sub(/^[[:space:]]*/, "", rest)
+            if (match(rest, /^[a-zA-Z]+/)) {
+                btype = substr(rest, 1, RLENGTH)
             } else {
                 btype = ""
             }
@@ -54,7 +58,8 @@ find "$REPO_ROOT" -type f -name "*.md" \
         cmd = $0
         sub(/^[[:space:]]*/, "", cmd)
         sub(/[[:space:]]*$/, "", cmd)
-        if (length(cmd) > 0) {
+        # Skip structural brackets and empty commands
+        if (length(cmd) > 0 && cmd != "{" && cmd != "}") {
             if (index(FILENAME, root) == 1) {
                 rel_path = substr(FILENAME, length(root) + 1)
             } else {


### PR DESCRIPTION
Improved the AWK-based markdown parser in `scripts/discover-commands.sh` to more robustly extract commands from code blocks. The changes include better language tag detection (handling optional spaces), expansion of supported shell types (zsh, fish), and improved filtering of non-command lines like structural braces.

---
*PR created automatically by Jules for task [17731051842520582969](https://jules.google.com/task/17731051842520582969) started by @d-o-hub*