### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix sed injection in version propagation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** Environment-overridable numeric variables used in `(( ))`, `$(( ))`, and `[[ $A -lt $B ]]` were vulnerable to command injection (e.g., `VAR='a[$(id)0]'`).
 **Learning:** Bash evaluates operands in arithmetic contexts as expressions. If a variable contains an array index like `a[$(...)0]`, the code inside `$(...)` is executed during evaluation.
 **Prevention:** Strictly validate that all variables used in Bash arithmetic contexts are numeric (e.g., using `[[ "$var" =~ ^[0-9]+$ ]]`) before they are evaluated.
+
+## 2026-05-15 - Sed Injection via Version File
+**Vulnerability:** The `propagate-version.sh` script used an unvalidated `VERSION` variable directly in `sed` substitution strings, which could lead to command execution if `sed` supports the `e` flag (e.g., `VERSION='1.2.3/e;s/.*/echo INJECTED/e;#'`).
+**Learning:** External files used as sources for shell script variables must be strictly validated even if they are internal to the repository, as they can be manipulated to achieve command injection in sensitive contexts like `sed`.
+**Prevention:** Use anchored regular expressions (e.g., `[[ "$var" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]`) to validate all variables derived from files before using them in shell commands or substitutions.

--- a/scripts/propagate-version.sh
+++ b/scripts/propagate-version.sh
@@ -20,6 +20,12 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+# Security: Validate version format to prevent injection in sed commands
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid version format '$VERSION'. Must be X.Y.Z"
+    exit 1
+fi
+
 echo "Propagating version $VERSION..."
 
 # Files that contain version badges or references


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Command injection (Sed injection) in `scripts/propagate-version.sh`.
🎯 Impact: A malicious actor with the ability to modify the `VERSION` file could execute arbitrary shell commands when the propagation script is run, particularly on systems where `sed` supports the `e` flag.
🔧 Fix: Implemented strict regex validation for the `VERSION` variable.
✅ Verification: Verified manually that valid versions are accepted and malicious payloads (e.g., `1.2.3/e;s/.*/echo INJECTED/e;#`) are rejected. All quality gates passed.

---
*PR created automatically by Jules for task [14902570215816960443](https://jules.google.com/task/14902570215816960443) started by @d-o-hub*