### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix command injection in propagate-version.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** Environment-overridable numeric variables used in `(( ))`, `$(( ))`, and `[[ $A -lt $B ]]` were vulnerable to command injection (e.g., `VAR='a[$(id)0]'`).
 **Learning:** Bash evaluates operands in arithmetic contexts as expressions. If a variable contains an array index like `a[$(...)0]`, the code inside `$(...)` is executed during evaluation.
 **Prevention:** Strictly validate that all variables used in Bash arithmetic contexts are numeric (e.g., using `[[ "$var" =~ ^[0-9]+$ ]]`) before they are evaluated.
+
+## 2026-05-04 - Command Injection via Bash sed Substitution
+**Vulnerability:** Unvalidated variables in Bash `sed` substitution commands, especially when the `e` (execute) flag is supported or delimiters are manipulated, can lead to command injection.
+**Learning:** Variables read from external files (like `VERSION`) must be treated as untrusted input before being used as patterns or replacement strings in `sed` to prevent arbitrary code execution or file corruption.
+**Prevention:** Enforce strict format validation (e.g., regex `^[0-9]+\.[0-9]+\.[0-9]+$`) for all external variables before passing them to `sed` or other shell commands.

--- a/scripts/propagate-version.sh
+++ b/scripts/propagate-version.sh
@@ -20,6 +20,12 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+# Security: Strictly validate semantic version format to prevent sed injection
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: VERSION must be a strict semantic version (e.g., 1.2.3)" >&2
+    exit 1
+fi
+
 echo "Propagating version $VERSION..."
 
 # Files that contain version badges or references


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix command injection in propagate-version.sh

🚨 Severity: MEDIUM
💡 Vulnerability: Unvalidated variable in `sed` substitution.
🎯 Impact: Potential arbitrary code execution if the `VERSION` file is compromised.
🔧 Fix: Added strict semantic version validation using regex `^[0-9]+\.[0-9]+\.[0-9]+$`.
✅ Verification: Tested with valid and malicious version strings (e.g., `1.2.3/e id`).


---
*PR created automatically by Jules for task [11110381483031993095](https://jules.google.com/task/11110381483031993095) started by @d-o-hub*