### PR TITLE
Add .claude-plugin/ manifest for Claude Code marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "github-template-ai-agents",
+  "owner": {
+    "name": "d-o-hub"
+  },
+  "metadata": {
+    "description": "Production-ready template for AI agent-powered development with Claude Code, Gemini CLI, and more."
+  },
+  "plugins": [
+    {
+      "name": "github-template-ai-agents",
+      "source": {
+        "source": "github",
+        "repo": "d-o-hub/github-template-ai-agents"
+      },
+      "description": "Unified harness for AI coding agents that provides consistent workflows across Claude Code, Gemini CLI, and more."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "github-template-ai-agents",
+  "description": "Production-ready template for AI agent-powered development with Claude Code, Gemini CLI, and more.",
+  "version": "0.2.8",
+  "author": {
+    "name": "d-o-hub"
+  },
+  "homepage": "https://github.com/d-o-hub/github-template-ai-agents",
+  "repository": "https://github.com/d-o-hub/github-template-ai-agents",
+  "license": "MIT",
+  "commands": "./.claude/commands",
+  "skills": "./.agents/skills",
+  "agents": [
+    "./.claude/agents/agent-creator.md",
+    "./.claude/agents/analysis-swarm.md",
+    "./.claude/agents/goap-agent.md",
+    "./.claude/agents/loop-agent.md"
+  ],
+  "hooks": "./.claude/hooks"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,11 @@ See `agents-docs/SUB-AGENTS.md`.
 
 ### Skills
 Skills live canonically in `.agents/skills/`. The `.claude/skills/` folder contains
-only symlinks. Run `./scripts/setup-skills.sh` once after cloning.
+only symlinks.
+
+**Installation**:
+- **One-click**: `claude skills install d-o-hub/github-template-ai-agents`
+- **Manual**: Run `./scripts/setup-skills.sh` once after cloning.
 
 Skills use progressive disclosure - `SKILL.md` is injected only when the agent
 decides the skill is needed. Do not pre-load all skills at session start.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ cd your-project
 
 ### Setup
 
+#### Option A: One-Click Install (Claude Code Only)
+
+```bash
+claude skills install d-o-hub/github-template-ai-agents
+```
+
+#### Option B: Manual Setup (All Agents)
+
 ```bash
 # Create skill symlinks (run once)
 ./scripts/setup-skills.sh


### PR DESCRIPTION
Add Claude Code plugin manifest files to enable one-click installation via the Claude Code CLI.

Summary of changes:
- Created `.claude-plugin/plugin.json` with plugin metadata, commands, skills, agents, and hooks.
- Created `.claude-plugin/marketplace.json` for the Claude marketplace listing.
- Updated `README.md` to include the one-click installation command.
- Updated `CLAUDE.md` to mention the plugin installation option.
- Verified changes with `scripts/quality_gate.sh`.

Fixes #293

---
*PR created automatically by Jules for task [13875323353315533214](https://jules.google.com/task/13875323353315533214) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-click plugin installation capability, enabling quick setup via Claude Code without manual configuration.

* **Documentation**
  * Updated setup guide with two installation paths: streamlined one-click install option for Claude Code users and detailed manual setup instructions for comprehensive control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->