### PR TITLE
fix: add missing 0.2.7 entry to CHANGELOG-TEMPLATE.md

### DIFF
--- a/CHANGELOG-TEMPLATE.md
+++ b/CHANGELOG-TEMPLATE.md
@@ -32,6 +32,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - perf(synthesis): optimize pairwise similarity in conflict check (#278)
 - perf: optimize link validation via batched awk processing (#279)
 
+## [0.2.7] - 2026-04-29
+
+### Added
+- feat(testing): add language-agnostic contract testing layer
+- feat(security): add Gitleaks for secret scanning and pre-commit hooks
+- feat(security): add explicit agent permission boundaries
+- Create gh-jules-setup.sh
+
+### Fixed
+- fix(security): prevent path traversal in evaluation framework
+- fix(quality-gate): remove duplicate headers and handle Windows symlinks
+- fix(security): implement fail-closed policy for SSRF DNS resolution
+- fix(security): prevent command injection in docling and ocr providers
+- fix(security): harden gh-labels-creator against argument injection
+
+### Changed
+- refactor(agents-md): prioritize instructions to overcome compliance ceiling
+- perf(scripts): optimize command discovery with awk and batched jq
+- perf(scripts): optimize validate-links.sh with single-pass awk
+- ci: bump actions and commitlint-github-action
+
 ## [0.2.6] - 2026-04-26
 
 ### Added


### PR DESCRIPTION
Version 0.2.7 was released on 2026-04-29 but its changes were omitted from the changelog because the patch version bump orchestration script was not yet available. This explicitly adds the 0.2.7 entries to resolve the missing version discrepancy in the CHANGELOG-TEMPLATE.md file.

---
*PR created automatically by Jules for task [9710335835693281174](https://jules.google.com/task/9710335835693281174) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to include historical release information for version 0.2.7, documenting additions, fixes, and changes from that release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->