### PR TITLE
🛡️ Sentinel: [medium] fix structural and option injection in ai-commit.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,6 +35,7 @@
 **Prevention:** Always use `printf "%s\n" "$VAR"` instead of `echo` for printing variables. Use the `--` separator with `grep` and other commands to terminate option processing before passing variables.
 
 ## 2026-05-09 - Structural and Option Injection in CLI Helpers
+
 **Vulnerability:** Use of `echo -e` and unquoted variables in `scripts/ai-commit.sh` allowed backslash sequences and leading hyphens in commit subjects/bodies to be interpreted as shell instructions or command options.
 **Learning:** `echo -e` expands escape sequences in user-controlled input, which can mangle data or enable structural injection. Variables starting with hyphens can be interpreted as flags if not handled with `printf` or `--`.
 **Prevention:** Always use `printf "%s\n"` instead of `echo` for printing variables. Use Bash literal newlines (`$'\n'`) for internal formatting to keep the data path clean and predictable.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,8 @@
 **Vulnerability:** Use of `echo "$VAR"` and `grep "$VAR"` in utility scripts allowed variables derived from `SKILL.md` (e.g., categories or skill names) to be interpreted as command-line options if they started with a hyphen.
 **Learning:** `echo` behavior is inconsistent when its first argument looks like a flag (e.g., `-e`). `grep` interprets patterns starting with `-` as options unless explicitly told not to.
 **Prevention:** Always use `printf "%s\n" "$VAR"` instead of `echo` for printing variables. Use the `--` separator with `grep` and other commands to terminate option processing before passing variables.
+
+## 2026-05-09 - Structural and Option Injection in CLI Helpers
+**Vulnerability:** Use of `echo -e` and unquoted variables in `scripts/ai-commit.sh` allowed backslash sequences and leading hyphens in commit subjects/bodies to be interpreted as shell instructions or command options.
+**Learning:** `echo -e` expands escape sequences in user-controlled input, which can mangle data or enable structural injection. Variables starting with hyphens can be interpreted as flags if not handled with `printf` or `--`.
+**Prevention:** Always use `printf "%s\n"` instead of `echo` for printing variables. Use Bash literal newlines (`$'\n'`) for internal formatting to keep the data path clean and predictable.

--- a/scripts/ai-commit.sh
+++ b/scripts/ai-commit.sh
@@ -53,17 +53,19 @@ MSG="${MSG}: ${SUBJECT}"
 
 # Add blank line and bodies
 if [ ${#BODIES[@]} -gt 0 ]; then
-    MSG="${MSG}\n"
+    MSG="${MSG}"$'\n'
     for BODY in "${BODIES[@]}"; do
         # Wrap body to 100 chars
-        WRAPPED_BODY=$(echo "$BODY" | fold -s -w 100)
-        MSG="${MSG}\n${WRAPPED_BODY}\n"
+        # Use printf to prevent option injection if BODY starts with -
+        WRAPPED_BODY=$(printf "%s\n" "$BODY" | fold -s -w 100)
+        MSG="${MSG}"$'\n'"${WRAPPED_BODY}"$'\n'
     done
 fi
 
 # Create temp file
 TMP_MSG=$(mktemp)
-echo -e "$MSG" > "$TMP_MSG"
+# Use printf %s to prevent interpretation of backslash escapes in user content
+printf "%s\n" "$MSG" > "$TMP_MSG"
 
 # Validate
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/scripts/ai-commit.sh
+++ b/scripts/ai-commit.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# Configuration
+BODY_WRAP_WIDTH=100
+
 TYPE=""
 SCOPE=""
 SUBJECT=""
@@ -55,15 +58,17 @@ MSG="${MSG}: ${SUBJECT}"
 if [ ${#BODIES[@]} -gt 0 ]; then
     MSG="${MSG}"$'\n'
     for BODY in "${BODIES[@]}"; do
-        # Wrap body to 100 chars
+        # Wrap body to prevent long lines in commit message
         # Use printf to prevent option injection if BODY starts with -
-        WRAPPED_BODY=$(printf "%s\n" "$BODY" | fold -s -w 100)
+        WRAPPED_BODY=$(printf "%s\n" "$BODY" | fold -s -w "$BODY_WRAP_WIDTH")
         MSG="${MSG}"$'\n'"${WRAPPED_BODY}"$'\n'
     done
 fi
 
-# Create temp file
+# Create temp file and ensure cleanup
 TMP_MSG=$(mktemp)
+trap 'rm -f "$TMP_MSG"' EXIT ERR
+
 # Use printf %s to prevent interpretation of backslash escapes in user content
 printf "%s\n" "$MSG" > "$TMP_MSG"
 
@@ -71,10 +76,8 @@ printf "%s\n" "$MSG" > "$TMP_MSG"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 if ! "$REPO_ROOT/scripts/validate-commit-message.sh" "$TMP_MSG"; then
     echo "Commit message validation failed."
-    rm "$TMP_MSG"
     exit 1
 fi
 
 # Commit
 git commit -F "$TMP_MSG"
-rm "$TMP_MSG"


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Structural and option injection via `echo -e` and unquoted variables.
- 🎯 Impact: Malicious or accidental input in commit subjects or bodies could be mangled or interpreted as shell options, leading to mangled commit messages or unexpected script behavior.
- 🔧 Fix: Replaced `echo -e` with `printf "%s\n"` and updated newline construction using `$'\n'`.
- ✅ Verification: Ran script with test payloads containing backslashes and leading hyphens, confirming they are preserved correctly in the output.

---
*PR created automatically by Jules for task [5770350275018668952](https://jules.google.com/task/5770350275018668952) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security finding entry documenting structural/option injection risks in commit tooling, with mitigation guidance and safe-handling recommendations.

* **Chores**
  * Improved commit-message generation to handle newlines and quoting more safely, reducing risk of escape/interpretation issues and increasing robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/github-template-ai-agents/pull/310)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->