### PR TITLE
🛡️ Sentinel: [security improvement] harden scripts against injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,7 +34,8 @@
 **Learning:** `echo` behavior is inconsistent when its first argument looks like a flag (e.g., `-e`). `grep` interprets patterns starting with `-` as options unless explicitly told not to.
 **Prevention:** Always use `printf "%s\n" "$VAR"` instead of `echo` for printing variables. Use the `--` separator with `grep` and other commands to terminate option processing before passing variables.
 
-## 2026-05-14 - Structural and Option Injection in Commit Tooling
+## 2026-05-10 - Structural and Option Injection in Commit Tooling
+
 **Vulnerability:** `scripts/ai-commit.sh` used `echo -e` to write commit messages to temporary files, allowing backslash escape sequences in agent-generated input to manipulate message structure. It also used `echo` for variable wrapping, susceptible to option injection.
 **Learning:** `echo -e` interprets escapes like `\n` in the variable content itself, not just the format string. This can lead to structural injection when the output is written to a file or piped.
 **Prevention:** Use `printf "%s\n"` for all variable output. Use literal newlines (`$'\n'`) for intentional line breaks in variables. Always implement `trap` cleanup for temporary files.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -33,3 +33,8 @@
 **Vulnerability:** Use of `echo "$VAR"` and `grep "$VAR"` in utility scripts allowed variables derived from `SKILL.md` (e.g., categories or skill names) to be interpreted as command-line options if they started with a hyphen.
 **Learning:** `echo` behavior is inconsistent when its first argument looks like a flag (e.g., `-e`). `grep` interprets patterns starting with `-` as options unless explicitly told not to.
 **Prevention:** Always use `printf "%s\n" "$VAR"` instead of `echo` for printing variables. Use the `--` separator with `grep` and other commands to terminate option processing before passing variables.
+
+## 2026-05-14 - Structural and Option Injection in Commit Tooling
+**Vulnerability:** `scripts/ai-commit.sh` used `echo -e` to write commit messages to temporary files, allowing backslash escape sequences in agent-generated input to manipulate message structure. It also used `echo` for variable wrapping, susceptible to option injection.
+**Learning:** `echo -e` interprets escapes like `\n` in the variable content itself, not just the format string. This can lead to structural injection when the output is written to a file or piped.
+**Prevention:** Use `printf "%s\n"` for all variable output. Use literal newlines (`$'\n'`) for intentional line breaks in variables. Always implement `trap` cleanup for temporary files.

--- a/scripts/ai-commit.sh
+++ b/scripts/ai-commit.sh
@@ -4,6 +4,9 @@
 
 set -euo pipefail
 
+# Configuration
+readonly BODY_WRAP_WIDTH=100
+
 TYPE=""
 SCOPE=""
 SUBJECT=""
@@ -53,26 +56,29 @@ MSG="${MSG}: ${SUBJECT}"
 
 # Add blank line and bodies
 if [ ${#BODIES[@]} -gt 0 ]; then
-    MSG="${MSG}\n"
+    MSG="${MSG}"$'\n'
     for BODY in "${BODIES[@]}"; do
-        # Wrap body to 100 chars
-        WRAPPED_BODY=$(echo "$BODY" | fold -s -w 100)
-        MSG="${MSG}\n${WRAPPED_BODY}\n"
+        # Wrap body to $BODY_WRAP_WIDTH chars
+        # Security: Use printf for safe variable expansion and prevent option injection
+        WRAPPED_BODY=$(printf "%s\n" "$BODY" | fold -s -w "$BODY_WRAP_WIDTH")
+        MSG="${MSG}"$'\n'"${WRAPPED_BODY}"$'\n'
     done
 fi
 
 # Create temp file
 TMP_MSG=$(mktemp)
-echo -e "$MSG" > "$TMP_MSG"
+# Security: Ensure cleanup of temporary commit message file
+trap 'rm -f "$TMP_MSG"' EXIT ERR
+
+# Security: Use printf for safe variable writing and to prevent backslash interpretation (structural injection)
+printf "%s\n" "$MSG" > "$TMP_MSG"
 
 # Validate
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 if ! "$REPO_ROOT/scripts/validate-commit-message.sh" "$TMP_MSG"; then
     echo "Commit message validation failed."
-    rm "$TMP_MSG"
     exit 1
 fi
 
 # Commit
 git commit -F "$TMP_MSG"
-rm "$TMP_MSG"

--- a/scripts/ai-commit.sh
+++ b/scripts/ai-commit.sh
@@ -74,7 +74,7 @@ trap 'rm -f "$TMP_MSG"' EXIT ERR
 printf "%s\n" "$MSG" > "$TMP_MSG"
 
 # Validate
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if ! "$REPO_ROOT/scripts/validate-commit-message.sh" "$TMP_MSG"; then
     echo "Commit message validation failed."
     exit 1

--- a/scripts/gh-labels-creator.sh
+++ b/scripts/gh-labels-creator.sh
@@ -30,9 +30,10 @@ else
         label_names=$(gh label list --json name --jq '.[].name')
 
         if [[ -n "$label_names" ]]; then
-            echo "$label_names" | while IFS= read -r label; do
+            # Security: Use printf for safe variable expansion and prevent option injection
+            printf "%s\n" "$label_names" | while IFS= read -r label; do
                 if [[ -n "$label" ]]; then
-                    echo "Deleting label: $label"
+                    printf "Deleting label: %s\n" "$label"
                     # Place flags before -- to ensure they are correctly parsed
                     gh label delete --yes -- "$label" || echo "Failed to delete: $label"
                 fi


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `echo -e` and `echo` usage with user-controlled variables in `ai-commit.sh` and `gh-labels-creator.sh` allowed for structural and option injection.
🎯 Impact: Malicious or accidental input could manipulate commit message structure or trigger unexpected script behavior.
🔧 Fix: Replaced `echo` with `printf "%s\n"`, used literal newlines for message construction, and added `trap` cleanup for temporary files.
✅ Verification: Ran `scripts/quality_gate.sh` and verified script logic.

---
*PR created automatically by Jules for task [4093202745445184598](https://jules.google.com/task/4093202745445184598) started by @d-o-hub*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security entry documenting identified structural and option injection risks and recommended mitigations.

* **Bug Fixes**
  * Improved commit message handling for safer string processing and added automatic temporary file cleanup.
  * Made label-management output more robust to avoid unsafe string/option interpretation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/d-o-hub/github-template-ai-agents/pull/312)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->