### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -63,3 +63,8 @@
 **Learning:** Even internal library functions are vulnerable if they handle variables that might be influenced by external input (e.g., branch names from git, or cached file names).
 
 **Prevention:** Always use the `--` separator before positional arguments in shell commands to terminate option processing. Use `printf` instead of `echo`. Implement strict path validation (canonicalization with `realpath -m`, root/dangerous path rejection, and boundary checks) before recursive deletions. Use exact ref checks (`git rev-parse`) instead of partial string matching for branch verification.
+
+## 2026-05-22 - Octal Interpretation Errors in Bash Arithmetic
+**Vulnerability:** Arithmetic expansion in Bash ($(( ))) interprets numbers with leading zeros as octal, causing errors for values like '08' or '09'.
+**Learning:** Logic for version comparison or numeric validation can crash if it handles version strings or numeric input with leading zeros without specifying the base.
+**Prevention:** Use the 10# prefix (e.g., $((10#$var))) to force decimal interpretation in Bash arithmetic expansion when dealing with potentially padded numbers.

--- a/scripts/lib/skill-validation.sh
+++ b/scripts/lib/skill-validation.sh
@@ -113,7 +113,7 @@ validate_skill_file() {
             fi
 
             if [[ "$s_major" -lt "$c_major" ]] || \
-               { [[ "$s_major" -eq "$c_major" ]] && [[ $((c_minor - s_minor)) -gt 1 ]]; }; then
+               { [[ "$s_major" -eq "$c_major" ]] && [[ $((10#$c_minor - 10#$s_minor)) -gt 1 ]]; }; then
                 printf "  %b⚠%b %s: template_version %s is >1 minor behind current %s\n" "${YELLOW}" "${NC}" "$skill_name" "$template_version" "$current_version" >&2
             fi
         fi

--- a/tests/verify-version-logic.sh
+++ b/tests/verify-version-logic.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Tests the version comparison logic from scripts/lib/skill-validation.sh
+# Specifically tests the hardening against octal interpretation and malformed input.
+
+set -uo pipefail
+
+# Mock environment
+SKILL_NAME="test-skill"
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+# Function to test (extracted and slightly adapted for standalone testing)
+# We test the core arithmetic logic:
+# if [[ "$s_major" -lt "$c_major" ]] || \
+#    { [[ "$s_major" -eq "$c_major" ]] && [[ $((10#$c_minor - 10#$s_minor)) -gt 1 ]]; }; then
+#     ...
+# fi
+test_version_diff() {
+    local c_major="$1"
+    local c_minor="$2"
+    local s_major="$3"
+    local s_minor="$4"
+    local expected_warning="$5"
+    local skill_name="test-skill"
+    local template_version="${s_major}.${s_minor}"
+    local current_version="${c_major}.${c_minor}"
+
+    # Pre-arithmetic validation (as in the script)
+    if [[ ! "$c_major" =~ ^[0-9]+$ ]] || [[ ! "$c_minor" =~ ^[0-9]+$ ]] || \
+       [[ ! "$s_major" =~ ^[0-9]+$ ]] || [[ ! "$s_minor" =~ ^[0-9]+$ ]]; then
+        c_major=0; c_minor=0; s_major=0; s_minor=0
+    fi
+
+    # The actual logic being tested
+    local warning=""
+    if [[ "$s_major" -lt "$c_major" ]] || \
+       { [[ "$s_major" -eq "$c_major" ]] && [[ $((10#$c_minor - 10#$s_minor)) -gt 1 ]]; }; then
+        warning="template_version ${template_version} is >1 minor behind current ${current_version}"
+    fi
+
+    if [[ "$warning" == *"$expected_warning"* ]] && [[ -n "$expected_warning" || -z "$warning" ]]; then
+        printf "  \033[0;32m✓\033[0m Test Passed: %s.%s vs %s.%s (Expected: '%s')\n" "$s_major" "$s_minor" "$c_major" "$c_minor" "$expected_warning"
+        return 0
+    else
+        printf "  \033[0;31m✗\033[0m Test Failed: %s.%s vs %s.%s\n" "$s_major" "$s_minor" "$c_major" "$c_minor"
+        printf "    Expected warning containing: '%s'\n" "$expected_warning"
+        printf "    Actual warning: '%s'\n" "$warning"
+        return 1
+    fi
+}
+
+echo "Running version comparison logic tests..."
+
+FAILED=0
+
+# Case 1: Leading zeros (the main fix)
+# 0.08 vs 0.10 -> diff 2 -> Warning expected
+test_version_diff "0" "10" "0" "08" "is >1 minor behind" || FAILED=1
+# 0.09 vs 0.10 -> diff 1 -> No warning expected
+test_version_diff "0" "10" "0" "09" "" || FAILED=1
+
+# Case 2: Major version behind -> Warning expected
+test_version_diff "1" "0" "0" "9" "is >1 minor behind" || FAILED=1
+
+# Case 3: Exactly 1 minor behind -> No warning expected
+test_version_diff "1" "2" "1" "1" "" || FAILED=1
+
+# Case 4: Malformed input (Injection attempt)
+# If c_minor contains injection, it should be caught by regex and set to 0.
+test_version_diff "0" "1 + \$(touch /tmp/PWNED)" "0" "0" "" || FAILED=1
+if [ -f /tmp/PWNED ]; then
+    echo "  ✗ SECURITY FAILURE: Injection executed!"
+    rm /tmp/PWNED
+    FAILED=1
+else
+    echo "  ✓ Security Check: No injection executed."
+fi
+
+if [ $FAILED -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

### 🚨 Severity: LOW (Robustness Enhancement)

### 💡 Vulnerability
Logic error in version comparison leading to script crash due to Bash's octal interpretation of numbers with leading zeros.

### 🎯 Impact
CI/CD validation failure when template versions contain leading zeros (e.g. 0.8), potentially blocking deployments or causing unreliable validation results.

### 🔧 Fix
Used the `10#` base prefix in arithmetic expansion within `scripts/lib/skill-validation.sh` to force decimal interpretation of version components.

### ✅ Verification
- Ran `scripts/quality_gate.sh` to ensure all checks pass.
- Verified the base-10 behavior with targeted bash scripts.

---
*PR created automatically by Jules for task [11896731769857772177](https://jules.google.com/task/11896731769857772177) started by @d-o-hub*