### PR TITLE
Replace empty GEMINI.md and QWEN.md stubs with agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 # AGENTS.md
 
 > Single source of truth for all AI coding agents in this repository.
-> Supported by: Claude Code, Windsurf, Gemini CLI, Codex, Copilot, OpenCode, Devin, Amp, Zed, Warp, RooCode, Jules
-> See: <https://agents.md>
 
 <!-- Agent-specific guidance: CLAUDE.md, GEMINI.md, QWEN.md, JULES.md -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 > Supported by: Claude Code, Windsurf, Gemini CLI, Codex, Copilot, OpenCode, Devin, Amp, Zed, Warp, RooCode, Jules
 > See: <https://agents.md>
 
+<!-- Agent-specific guidance: CLAUDE.md, GEMINI.md, QWEN.md, JULES.md -->
+
 ## Named Constants
 
 ```bash

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,9 @@
-@AGENTS.md
+# Gemini Agent Guidelines
+
+This project uses a unified agent framework. **All rules, skills, and workflows are defined in [`AGENTS.md`](./AGENTS.md).**
+
+Gemini-specific notes:
+- Prefer `agents-docs/` for context before asking clarifying questions
+- Use the skills in `.agents/skills/` for structured tasks
+- Always append task results to `.agents/metrics.jsonl` after each task
+- Check `ci-status.json` before making any changes

--- a/JULES.md
+++ b/JULES.md
@@ -1,0 +1,9 @@
+# Jules Agent Guidelines
+
+This project uses a unified agent framework. **All rules, skills, and workflows are defined in [`AGENTS.md`](./AGENTS.md).**
+
+Jules-specific notes:
+- See `.jules/bolt.md` for performance-specific learnings and technical rules
+- Reference `.jules/sentinel.md` for high-level codebase context and architectural patterns
+- Always follow the atomic commit workflow defined in `AGENTS.md`
+- Check `ci-status.json` before making any changes

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,1 +1,9 @@
-@AGENTS.md
+# Qwen Agent Guidelines
+
+This project uses a unified agent framework. **All rules, skills, and workflows are defined in [`AGENTS.md`](./AGENTS.md).**
+
+Qwen-specific notes:
+- Prefer `agents-docs/` for context before asking clarifying questions
+- Use the skills in `.agents/skills/` for structured tasks
+- Always append task results to `.agents/metrics.jsonl` after each task
+- Check `ci-status.json` before making any changes

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,8 +1,6 @@
 {
-  "status": "failing",
-  "last_run": "2026-05-30T19:47:48.815860Z",
-  "failing_jobs": [
-    "quality-gate"
-  ],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
+  "status": "passing",
+  "last_run": "2026-05-30T20:09:29.163925Z",
+  "failing_jobs": [],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693696667"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,8 +1,6 @@
 {
-  "status": "failing",
-  "last_run": "2026-05-30T19:47:48.815860Z",
-  "failing_jobs": [
-    "quality-gate"
-  ],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
+  "status": "passing",
+  "last_run": "2026-05-30T20:02:12.588767Z",
+  "failing_jobs": [],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693538740"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,8 +1,6 @@
 {
-  "status": "failing",
-  "last_run": "2026-05-30T19:47:48.815860Z",
-  "failing_jobs": [
-    "quality-gate"
-  ],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
+  "status": "passing",
+  "last_run": "2026-05-30T20:14:49.249214Z",
+  "failing_jobs": [],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693810127"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,8 +1,6 @@
 {
-  "status": "failing",
-  "last_run": "2026-05-30T19:47:48.815860Z",
-  "failing_jobs": [
-    "quality-gate"
-  ],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
+  "status": "passing",
+  "last_run": "2026-05-30T20:05:48.029369Z",
+  "failing_jobs": [],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693616159"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,6 +1,8 @@
 {
-  "status": "passing",
-  "last_run": "2026-05-30T20:02:12.588767Z",
-  "failing_jobs": [],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693538740"
+  "status": "failing",
+  "last_run": "2026-05-30T19:47:48.815860Z",
+  "failing_jobs": [
+    "quality-gate"
+  ],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,6 +1,8 @@
 {
-  "status": "passing",
-  "last_run": "2026-05-30T20:09:29.163925Z",
-  "failing_jobs": [],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693696667"
+  "status": "failing",
+  "last_run": "2026-05-30T19:47:48.815860Z",
+  "failing_jobs": [
+    "quality-gate"
+  ],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,6 +1,6 @@
 {
   "status": "passing",
-  "last_run": "2026-05-30T20:14:49.249214Z",
+  "last_run": "2026-05-30T21:06:20.934543Z",
   "failing_jobs": [],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693810127"
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26694897923"
 }

--- a/ci-status.json
+++ b/ci-status.json
@@ -1,6 +1,8 @@
 {
-  "status": "passing",
-  "last_run": "2026-05-30T20:05:48.029369Z",
-  "failing_jobs": [],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693616159"
+  "status": "failing",
+  "last_run": "2026-05-30T19:47:48.815860Z",
+  "failing_jobs": [
+    "quality-gate"
+  ],
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367"
 }

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **failing**
+Latest CI status: **passing**
 
-- **Last Run:** 2026-05-30T19:47:48.815860Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
+- **Last Run:** 2026-05-30T20:02:12.588767Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693538740](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693538740)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ❌ failure |
-| test | ⏭️ skipped |
+| quality-gate | ✅ success |
+| test | ✅ success |

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **passing**
+Latest CI status: **failing**
 
-- **Last Run:** 2026-05-30T20:05:48.029369Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693616159](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693616159)
+- **Last Run:** 2026-05-30T19:47:48.815860Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ✅ success |
-| test | ✅ success |
+| quality-gate | ❌ failure |
+| test | ⏭️ skipped |

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **failing**
+Latest CI status: **passing**
 
-- **Last Run:** 2026-05-30T19:47:48.815860Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
+- **Last Run:** 2026-05-30T20:14:49.249214Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693810127](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693810127)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ❌ failure |
-| test | ⏭️ skipped |
+| quality-gate | ✅ success |
+| test | ✅ success |

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **passing**
+Latest CI status: **failing**
 
-- **Last Run:** 2026-05-30T20:09:29.163925Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693696667](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693696667)
+- **Last Run:** 2026-05-30T19:47:48.815860Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ✅ success |
-| test | ✅ success |
+| quality-gate | ❌ failure |
+| test | ⏭️ skipped |

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **passing**
+Latest CI status: **failing**
 
-- **Last Run:** 2026-05-30T20:02:12.588767Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693538740](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693538740)
+- **Last Run:** 2026-05-30T19:47:48.815860Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ✅ success |
-| test | ✅ success |
+| quality-gate | ❌ failure |
+| test | ⏭️ skipped |

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **failing**
+Latest CI status: **passing**
 
-- **Last Run:** 2026-05-30T19:47:48.815860Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
+- **Last Run:** 2026-05-30T20:05:48.029369Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693616159](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693616159)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ❌ failure |
-| test | ⏭️ skipped |
+| quality-gate | ✅ success |
+| test | ✅ success |

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -2,8 +2,8 @@
 
 Latest CI status: **passing**
 
-- **Last Run:** 2026-05-30T20:14:49.249214Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693810127](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693810127)
+- **Last Run:** 2026-05-30T21:06:20.934543Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26694897923](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26694897923)
 
 ## Job Status
 

--- a/ci-summary.md
+++ b/ci-summary.md
@@ -1,14 +1,14 @@
 # CI Summary
 
-Latest CI status: **failing**
+Latest CI status: **passing**
 
-- **Last Run:** 2026-05-30T19:47:48.815860Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693254367)
+- **Last Run:** 2026-05-30T20:09:29.163925Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693696667](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/26693696667)
 
 ## Job Status
 
 | Job | Result |
 | --- | --- |
 | labels | ✅ success |
-| quality-gate | ❌ failure |
-| test | ⏭️ skipped |
+| quality-gate | ✅ success |
+| test | ✅ success |


### PR DESCRIPTION
This PR replaces the empty stubs for `GEMINI.md` and `QWEN.md` with meaningful agent-specific guidance, as requested. It also creates `JULES.md` and updates `AGENTS.md` to reference these files. This ensures that agents loading the repository receive clear instructions while maintaining `AGENTS.md` as the single source of truth.

Key changes:
- Updated `GEMINI.md` with Gemini-specific notes.
- Updated `QWEN.md` with Qwen-specific notes.
- Created `JULES.md` referencing technical rules and architectural context.
- Added a reference comment to `AGENTS.md`.
- Verified all changes against repository quality gates.

Fixes #385

---
*PR created automatically by Jules for task [12194791080064613282](https://jules.google.com/task/12194791080064613282) started by @d-o-hub*