### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden Bash scripts against octal interpretation

### DIFF
--- a/scripts/bump_patch_version.sh
+++ b/scripts/bump_patch_version.sh
@@ -24,7 +24,8 @@ MAJOR="${BASH_REMATCH[1]}"
 MINOR="${BASH_REMATCH[2]}"
 PATCH="${BASH_REMATCH[3]}"
 
-NEW_PATCH=$((PATCH + 1))
+# Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
+NEW_PATCH=$((10#$PATCH + 1))
 NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
 CURRENT_DATE=$(date +"%Y-%m-%d")
 RECENT_COMMIT_COUNT=15

--- a/scripts/lib/skill-validation.sh
+++ b/scripts/lib/skill-validation.sh
@@ -112,8 +112,8 @@ validate_skill_file() {
                 c_major=0; c_minor=0; s_major=0; s_minor=0
             fi
 
-            if [[ "$s_major" -lt "$c_major" ]] || \
-               { [[ "$s_major" -eq "$c_major" ]] && [[ $((10#$c_minor - 10#$s_minor)) -gt 1 ]]; }; then
+            if (( 10#$s_major < 10#$c_major )) || \
+               { (( 10#$s_major == 10#$c_major )) && (( 10#$c_minor - 10#$s_minor > 1 )); }; then
                 printf "  %b⚠%b %s: template_version %s is >1 minor behind current %s\n" "${YELLOW}" "${NC}" "$skill_name" "$template_version" "$current_version" >&2
             fi
         fi

--- a/scripts/loc_gate.sh
+++ b/scripts/loc_gate.sh
@@ -32,7 +32,7 @@ echo "Checking LOC limits..."
 if [[ -f "$AGENTS_MD_FILE" ]]; then
     LOC=$(wc -l < "$AGENTS_MD_FILE")
     # Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
-    if (( 10#${LOC// /} > 10#$MAX_AGENTS )); then
+    if (( 10#$LOC > 10#$MAX_AGENTS )); then
         echo "ERROR: $AGENTS_MD_FILE has $LOC lines (max $MAX_AGENTS)" >&2
         FAILED=1
     fi
@@ -43,7 +43,7 @@ fi
 if ! find .agents/skills -name "SKILL.md" -not -path "*/node_modules/*" -print0 | \
     xargs -0 -r wc -l -- | \
     awk -v max="${MAX_SKILL_OVERRIDE:-$MAX_SKILL}" -- '
-    BEGIN { err = 0 }
+    BEGIN { err = 0; if (max ~ /^0[0-9]+/) max = substr(max, 2) }
     $NF == "total" { next }
     $1 + 0 > max + 0 {
         count = $1
@@ -69,7 +69,7 @@ if ! find . -type f \( -name "*.py" -o -name "*.rs" -o -name "*.ts" -o -name "*.
     -not -path "./.agents/skills/*" -print0 | \
     xargs -0 -r wc -l -- | \
     awk -v max="${MAX_SOURCE_OVERRIDE:-$MAX_SOURCE}" -- '
-    BEGIN { err = 0; sub(/^0+/, "", max); if (max == "") max = 0 }
+    BEGIN { err = 0; if (max ~ /^0[0-9]+/) max = substr(max, 2) }
     $NF == "total" { next }
     $1 + 0 > max + 0 {
         count = $1

--- a/scripts/loc_gate.sh
+++ b/scripts/loc_gate.sh
@@ -31,7 +31,8 @@ echo "Checking LOC limits..."
 # 1. Check AGENTS.md
 if [[ -f "$AGENTS_MD_FILE" ]]; then
     LOC=$(wc -l < "$AGENTS_MD_FILE")
-    if [[ "$LOC" -gt "$MAX_AGENTS" ]]; then
+    # Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
+    if (( 10#$LOC > 10#$MAX_AGENTS )); then
         echo "ERROR: $AGENTS_MD_FILE has $LOC lines (max $MAX_AGENTS)" >&2
         FAILED=1
     fi
@@ -42,9 +43,9 @@ fi
 if ! find .agents/skills -name "SKILL.md" -not -path "*/node_modules/*" -print0 | \
     xargs -0 -r wc -l -- | \
     awk -v max="${MAX_SKILL_OVERRIDE:-$MAX_SKILL}" -- '
-    BEGIN { err = 0 }
+    BEGIN { err = 0; if (max ~ /^0[0-9]+/) max = substr(max, 2) }
     $NF == "total" { next }
-    $1 > max {
+    $1 + 0 > max + 0 {
         count = $1
         $1 = ""
         sub(/^[[:space:]]+/, "")
@@ -68,9 +69,9 @@ if ! find . -type f \( -name "*.py" -o -name "*.rs" -o -name "*.ts" -o -name "*.
     -not -path "./.agents/skills/*" -print0 | \
     xargs -0 -r wc -l -- | \
     awk -v max="${MAX_SOURCE_OVERRIDE:-$MAX_SOURCE}" -- '
-    BEGIN { err = 0 }
+    BEGIN { err = 0; if (max ~ /^0[0-9]+/) max = substr(max, 2) }
     $NF == "total" { next }
-    $1 > max {
+    $1 + 0 > max + 0 {
         count = $1
         $1 = ""
         sub(/^[[:space:]]+/, "")

--- a/scripts/loc_gate.sh
+++ b/scripts/loc_gate.sh
@@ -69,7 +69,7 @@ if ! find . -type f \( -name "*.py" -o -name "*.rs" -o -name "*.ts" -o -name "*.
     -not -path "./.agents/skills/*" -print0 | \
     xargs -0 -r wc -l -- | \
     awk -v max="${MAX_SOURCE_OVERRIDE:-$MAX_SOURCE}" -- '
-    BEGIN { err = 0; if (max ~ /^0[0-9]+/) max = substr(max, 2) }
+    BEGIN { err = 0; sub(/^0+/, "", max); if (max == "") max = 0 }
     $NF == "total" { next }
     $1 + 0 > max + 0 {
         count = $1

--- a/scripts/loc_gate.sh
+++ b/scripts/loc_gate.sh
@@ -32,7 +32,7 @@ echo "Checking LOC limits..."
 if [[ -f "$AGENTS_MD_FILE" ]]; then
     LOC=$(wc -l < "$AGENTS_MD_FILE")
     # Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
-    if (( 10#$LOC > 10#$MAX_AGENTS )); then
+    if (( 10#${LOC// /} > 10#$MAX_AGENTS )); then
         echo "ERROR: $AGENTS_MD_FILE has $LOC lines (max $MAX_AGENTS)" >&2
         FAILED=1
     fi

--- a/scripts/loc_gate.sh
+++ b/scripts/loc_gate.sh
@@ -43,7 +43,7 @@ fi
 if ! find .agents/skills -name "SKILL.md" -not -path "*/node_modules/*" -print0 | \
     xargs -0 -r wc -l -- | \
     awk -v max="${MAX_SKILL_OVERRIDE:-$MAX_SKILL}" -- '
-    BEGIN { err = 0; if (max ~ /^0[0-9]+/) max = substr(max, 2) }
+    BEGIN { err = 0 }
     $NF == "total" { next }
     $1 + 0 > max + 0 {
         count = $1

--- a/scripts/update-agents-md.sh
+++ b/scripts/update-agents-md.sh
@@ -145,8 +145,9 @@ if [[ -d "$REPO_ROOT/.agents/skills" ]]; then
 fi
 
 # Sort the table rows (excluding header) alphabetically by skill name
-head -n $((SKILLS_SECTION_LINE + 3)) -- "$TEMP_FILE" > "$UPDATE_AGENTS_TEMP_TABLE"
-tail -n +$((SKILLS_SECTION_LINE + 4)) -- "$TEMP_FILE" | sort >> "$UPDATE_AGENTS_TEMP_TABLE"
+# Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
+head -n $((10#$SKILLS_SECTION_LINE + 3)) -- "$TEMP_FILE" > "$UPDATE_AGENTS_TEMP_TABLE"
+tail -n +$((10#$SKILLS_SECTION_LINE + 4)) -- "$TEMP_FILE" | sort >> "$UPDATE_AGENTS_TEMP_TABLE"
 mv -- "$UPDATE_AGENTS_TEMP_TABLE" "$TEMP_FILE"
 
 # Add empty line before next section

--- a/scripts/update-agents-md.sh
+++ b/scripts/update-agents-md.sh
@@ -146,8 +146,8 @@ fi
 
 # Sort the table rows (excluding header) alphabetically by skill name
 # Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
-head -n $((10#$SKILLS_SECTION_LINE + 3)) -- "$TEMP_FILE" > "$UPDATE_AGENTS_TEMP_TABLE"
-tail -n +$((10#$SKILLS_SECTION_LINE + 4)) -- "$TEMP_FILE" | sort >> "$UPDATE_AGENTS_TEMP_TABLE"
+head -n $((10#0$SKILLS_SECTION_LINE + 3)) -- "$TEMP_FILE" > "$UPDATE_AGENTS_TEMP_TABLE"
+tail -n +$((10#0$SKILLS_SECTION_LINE + 4)) -- "$TEMP_FILE" | sort >> "$UPDATE_AGENTS_TEMP_TABLE"
 mv -- "$UPDATE_AGENTS_TEMP_TABLE" "$TEMP_FILE"
 
 # Add empty line before next section

--- a/scripts/update-agents-md.sh
+++ b/scripts/update-agents-md.sh
@@ -146,8 +146,8 @@ fi
 
 # Sort the table rows (excluding header) alphabetically by skill name
 # Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
-head -n $((10#0$SKILLS_SECTION_LINE + 3)) -- "$TEMP_FILE" > "$UPDATE_AGENTS_TEMP_TABLE"
-tail -n +$((10#0$SKILLS_SECTION_LINE + 4)) -- "$TEMP_FILE" | sort >> "$UPDATE_AGENTS_TEMP_TABLE"
+head -n $((10#$SKILLS_SECTION_LINE + 3)) -- "$TEMP_FILE" > "$UPDATE_AGENTS_TEMP_TABLE"
+tail -n +$((10#$SKILLS_SECTION_LINE + 4)) -- "$TEMP_FILE" | sort >> "$UPDATE_AGENTS_TEMP_TABLE"
 mv -- "$UPDATE_AGENTS_TEMP_TABLE" "$TEMP_FILE"
 
 # Add empty line before next section

--- a/scripts/wasm_size_gate.sh
+++ b/scripts/wasm_size_gate.sh
@@ -46,7 +46,8 @@ fi
 if [[ -s "$TMP_OUT" ]]; then
     WASM_FOUND=1
     while IFS="|" read -r size file; do
-        if [[ "$size" -gt "$MAX_SIZE_BYTES" ]]; then
+        # Security: Use 10# to force decimal interpretation (handles leading zeros like 08)
+        if (( 10#$size > 10#$MAX_SIZE_BYTES )); then
             printf "ERROR: %s size %s exceeds limit %s\n" "$file" "$size" "$MAX_SIZE_BYTES"
             FAILED=1
         else

--- a/tests/test-security-fixes.sh
+++ b/tests/test-security-fixes.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # tests/test-security-fixes.sh - Verify security fixes and functional correctness
 
-set -euo pipefail
+set -uo pipefail
+
+# Store the project root
+PROJECT_ROOT=$(pwd)
 
 # Setup test environment
 TEST_ROOT=$(mktemp -d)
@@ -36,7 +39,7 @@ if [[ "$OUTPUT" == *"✓ Plan numbering consistent"* ]]; then
     echo "  ✓ Test 1 passed"
 else
     echo "  ✗ Test 1 failed: Output was: $OUTPUT"
-    exit 1
+    FAILED_TESTS=1
 fi
 
 # Test 2: Verify scripts/validate-skills.sh correctly counts rules
@@ -62,44 +65,29 @@ if echo "$OUTPUT" | grep -q "skill-rules.json: 2 rules defined"; then
     echo "  ✓ Test 2 passed"
 else
     echo "  ✗ Test 2 failed: Output was: $OUTPUT"
-    exit 1
+    FAILED_TESTS=1
 fi
 
 # Test 3: Security Check - Malicious variable interpolation
 echo "Test 3: Security check - Malicious variable interpolation..."
 
-# For check-plan-numbering.sh
-# We use a filename that would trigger injection if interpolated
 MALICIOUS_FILE="'); import os; os.system('echo INJECTED_PLAN'); print('"
-# Create the file so open() doesn't fail, even if we don't expect it to be used as a filename
 touch "$TEST_ROOT/$MALICIOUS_FILE"
 
-# Run check-plan-numbering.sh with STATUS_FILE set to malicious value
-# We need to export it or pass it so the script uses it
-# The script sets STATUS_FILE="$REPO_ROOT/plans/_status.json" internally,
-# so we need to mock REPO_ROOT or modify the script to test this,
-# but we can also just run the python command directly as the script does.
-
-# More realistic: The script uses STATUS_FILE="$REPO_ROOT/plans/_status.json"
-# If we can control REPO_ROOT we can trigger it.
-# However, the script sets REPO_ROOT internally.
-
-# Let's test the python command pattern used in the scripts
 echo "  Testing python command pattern from check-plan-numbering.sh..."
 if python3 -c "import json, sys; d=json.load(open(sys.argv[1])); print(d['nextAvailable']['plan'])" "$MALICIOUS_FILE" 2>/dev/null | grep -q "INJECTED_PLAN"; then
     echo "  ✗ Test 3a failed: Injection successful!"
-    exit 1
+    FAILED_TESTS=1
 else
     echo "  ✓ Test 3a passed: No injection via sys.argv"
 fi
 
-# For validate-skills.sh
 echo "  Testing python command pattern from validate-skills.sh..."
 MALICIOUS_RULES="'); import os; os.system('echo INJECTED_RULES'); print('"
 touch "$TEST_ROOT/$MALICIOUS_RULES"
 if python3 -c "import json, sys; print(len(json.load(open(sys.argv[1]))))" "$MALICIOUS_RULES" 2>/dev/null | grep -q "INJECTED_RULES"; then
     echo "  ✗ Test 3b failed: Injection successful!"
-    exit 1
+    FAILED_TESTS=1
 else
     echo "  ✓ Test 3b passed: No injection via sys.argv"
 fi
@@ -109,34 +97,127 @@ echo "All security and functional tests passed!"
 # Test 4: Option Injection Hardening in AWK and WC
 echo "Test 4: Option Injection Hardening in AWK and WC..."
 
-# Test filenames
 HYPHEN_FILE="-v"
 touch "$TEST_ROOT/$HYPHEN_FILE"
 echo "content" > "$TEST_ROOT/$HYPHEN_FILE"
 
-# Test 4a: awk handles hyphenated filenames correctly
 echo "  Testing awk hardening..."
 if (cd "$TEST_ROOT" && awk -- '1' "$HYPHEN_FILE" 2>/dev/null | grep -q "content"); then
     echo "  ✓ Test 4a passed: awk handled $HYPHEN_FILE correctly"
 else
     echo "  ✗ Test 4a failed: awk did not handle $HYPHEN_FILE correctly"
+    FAILED_TESTS=1
 fi
 
-# Test 4b: wc -l handles hyphenated filenames correctly
 echo "  Testing wc hardening..."
 if (cd "$TEST_ROOT" && wc -l -- "$HYPHEN_FILE" 2>/dev/null | grep -q "1 $HYPHEN_FILE"); then
     echo "  ✓ Test 4b passed: wc handled $HYPHEN_FILE correctly"
 else
     echo "  ✗ Test 4b failed: wc did not handle $HYPHEN_FILE correctly"
+    FAILED_TESTS=1
 fi
 
 # Test 5: xargs -r safety
 echo "Test 5: xargs -r safety..."
-# Ensure xargs -r doesn't run if input is empty
 if [[ $(printf "" | xargs -r echo "executed") == "" ]]; then
     echo "  ✓ Test 5 passed: xargs -r did not execute on empty input"
 else
     echo "  ✗ Test 5 failed: xargs -r executed on empty input"
+    FAILED_TESTS=1
 fi
 
 echo "Option injection and xargs tests passed!"
+
+# Test 6: Octal Interpretation Hardening
+echo "Test 6: Octal Interpretation Hardening..."
+
+# Test 6a: bump_patch_version.sh octal handling
+echo "  Testing bump_patch_version.sh octal handling (08 -> 9)..."
+mkdir -p "$TEST_ROOT/bump_test/scripts"
+cp "$PROJECT_ROOT/scripts/bump_patch_version.sh" "$TEST_ROOT/bump_test/scripts/"
+cp "$PROJECT_ROOT/scripts/propagate-version.sh" "$TEST_ROOT/bump_test/scripts/"
+(
+    cd "$TEST_ROOT/bump_test"
+    echo "0.1.08" > "VERSION"
+    echo "## [Unreleased]" > "CHANGELOG-TEMPLATE.md"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git add . && git commit -m "initial" -q
+    if bash scripts/bump_patch_version.sh > /dev/null 2>&1; then
+        NEW_V=$(cat VERSION)
+        if [[ "$NEW_V" == "0.1.9" ]]; then
+            echo "  ✓ Test 6a passed: 0.1.08 bumped to 0.1.9"
+        else
+            echo "  ✗ Test 6a failed: expected 0.1.9, got $NEW_V"
+            exit 1
+        fi
+    else
+        echo "  ✗ Test 6a failed: script crashed (likely octal error)"
+        exit 1
+    fi
+) || FAILED_TESTS=1
+
+# Test 6b: loc_gate.sh octal handling
+echo "  Testing loc_gate.sh octal handling..."
+mkdir -p "$TEST_ROOT/loc_test/scripts"
+mkdir -p "$TEST_ROOT/loc_test/.agents/skills"
+cp "$PROJECT_ROOT/scripts/loc_gate.sh" "$TEST_ROOT/loc_test/scripts/"
+(
+    cd "$TEST_ROOT/loc_test"
+    echo "MAX_LINES_AGENTS_MD=0150" > "AGENTS.md"
+    for i in {1..10}; do echo "line $i"; done >> "AGENTS.md"
+    if MAX_SKILL_OVERRIDE=080 bash scripts/loc_gate.sh > /dev/null 2>&1; then
+        echo "  ✓ Test 6b passed: loc_gate.sh handled leading zeros"
+    else
+        echo "  ✗ Test 6b failed: loc_gate.sh crashed or returned error"
+        exit 1
+    fi
+) || FAILED_TESTS=1
+
+# Test 6c: wasm_size_gate.sh octal handling
+echo "  Testing wasm_size_gate.sh octal handling..."
+mkdir -p "$TEST_ROOT/wasm_test/scripts"
+cp "$PROJECT_ROOT/scripts/wasm_size_gate.sh" "$TEST_ROOT/wasm_test/scripts/"
+(
+    cd "$TEST_ROOT/wasm_test"
+    touch "test.wasm"
+    if MAX_WASM_SIZE_BYTES=01048576 bash scripts/wasm_size_gate.sh > /dev/null 2>&1; then
+        echo "  ✓ Test 6c passed: wasm_size_gate.sh handled leading zeros"
+    else
+        echo "  ✗ Test 6c failed: wasm_size_gate.sh crashed or returned error"
+        exit 1
+    fi
+) || FAILED_TESTS=1
+
+# Test 6d: skill-validation.sh octal handling
+echo "  Testing skill-validation.sh octal handling (version 08/09)..."
+mkdir -p "$TEST_ROOT/skill_test/.agents/skills/test-skill"
+mkdir -p "$TEST_ROOT/skill_test/scripts/lib"
+cp "$PROJECT_ROOT/scripts/validate-skills.sh" "$TEST_ROOT/skill_test/scripts/"
+cp "$PROJECT_ROOT/scripts/lib/skill-validation.sh" "$TEST_ROOT/skill_test/scripts/lib/"
+(
+    cd "$TEST_ROOT/skill_test"
+    echo "0.2.10" > "VERSION"
+    cat <<SKILL > ".agents/skills/test-skill/SKILL.md"
+---
+name: test-skill
+description: test
+version: 1.0.0
+template_version: 0.08.0
+---
+SKILL
+    if bash scripts/validate-skills.sh > /dev/null 2>&1; then
+        echo "  ✓ Test 6d passed: skill-validation.sh handled leading zeros in version"
+    else
+        echo "  ✗ Test 6d failed: skill-validation.sh crashed or returned error"
+        exit 1
+    fi
+) || FAILED_TESTS=1
+
+if [[ ${FAILED_TESTS:-0} -ne 0 ]]; then
+    echo "Some tests failed!"
+    exit 1
+fi
+
+echo "Octal hardening tests passed!"


### PR DESCRIPTION
### 🛡️ Sentinel Security Update

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Bash interprets numbers with leading zeros as octal. Values like `08` or `09` cause "value too great for base" errors in arithmetic contexts `$((...))` or `((...))`.
🎯 **Impact**: Utility scripts (like quality gates and version bumbers) can crash or behave incorrectly when processing data with leading zeros, leading to a denial of service for CI/CD or potential logic bypasses.
🔧 **Fix**: Added the `10#` prefix to force decimal interpretation in Bash arithmetic and ensured `awk` scripts correctly handle decimal numeric comparisons.
✅ **Verification**: 
- Verified `quality_gate.sh` passes.
- Confirmed fix with manual test cases for `bump_patch_version.sh` and `loc_gate.sh` using leading-zero inputs.
- Verified that previously identified octal errors are now handled correctly.

---
*PR created automatically by Jules for task [9380830162608118095](https://jules.google.com/task/9380830162608118095) started by @d-o-hub*