### PR TITLE
feat(scripts): add bootstrap.sh and doctor.sh entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ graph LR
 - [Hooks](agents-docs/HOOKS.md) — pre/post tool hooks
 - [Context](agents-docs/CONTEXT.md) — back-pressure mechanisms
 - [Migration](agents-docs/MIGRATION.md) — adopting in existing projects
-- [Available Skills](.agents/skills/README.md) - agents skills overview 
+- [Available Skills](.agents/skills/README.md) — agents skills overview
 
 ## Contributing
 

--- a/agents-docs/SCRIPTS.md
+++ b/agents-docs/SCRIPTS.md
@@ -7,6 +7,8 @@
 
 | Script | Purpose | Usage |
 |--------|---------|-------|
+| `bootstrap.sh` | Single-command first-time setup (skills + hook + validate + gate) | `./scripts/bootstrap.sh` |
+| `doctor.sh` | Environment diagnostics for self-service troubleshooting | `./scripts/doctor.sh` |
 | `quality_gate.sh` | Multi-language quality gate (lint, test, format) | `./scripts/quality_gate.sh` |
 | `setup-skills.sh` | Create symlinks from `.agents/skills/` to CLI dirs | `./scripts/setup-skills.sh` |
 | `pre-commit-hook.sh` | Pre-commit hook template (copied by install-hooks.sh) | Installed via `install-hooks.sh` |

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,47 +1,98 @@
 # GOAP_STATE
 
-## Current State
+## Current Mission
 
-- **Branch**: `main`
-- **CI Status**: Fix pushed (`e3e72d5`), CI running — quality-gate should return to passing
-- **Open PRs**:
-  - PR #477: `ci: update ci status artifacts` — will auto-resolve when CI passes
+**Goal**: Implement all 7 open GitHub issues (#491-#497) using a multi-agent swarm, address all PR comments, ensure all GitHub Actions pass with zero warnings.
 
-### Dependabot Auto-Merge Rewrite (Completed)
+**Branch**: `main` (working from)
+**CI Status**: `passing` (verified `.github/ci-status/ci-status.json` 2026-06-05T16:47Z)
+**Open PRs**: 0 (will create 3)
+**Open Issues**: 7 (5 unique, 2 marked duplicate but contain unique content)
 
-- **Commits**: `5f73014`, `e2a650f`, `e92791b`, `b4086de`
-- **What changed**: Replaced manual check polling + direct REST `pulls.merge()` with GraphQL-based `enablePullRequestAutoMerge` (SQUASH) + `resolveReviewThread`
-- **ADR**: [ADR-007](adr-007-dependabot-auto-merge-ruleset.md) — documents ruleset requirements and how GraphQL satisfies them
-- **Learnings**: [LESSON-023](../agents-docs/LESSONS.md) — 5 root causes + 5 fixes for Dependabot auto-merge failure chain
-- **Tests**: 17 auto-merge BATS tests (11 positive + 6 negative regression) — all passing
-- **Additional fixes**:
-  - `ci-and-labels.yml`: Skip `update-ci-status` on Dependabot PRs (`github.actor` guard)
-  - Removed dead `getCombinedStatusForRef` from auto-merge workflow
-  - Created `pre-commit` label for Dependabot pre-commit ecosystem
+## Issue Inventory
+
+| # | Title | File scope | Deps |
+|---|-------|------------|------|
+| 491 | README hero rewrite | `README.md` | — |
+| 492 | Why this template section | `README.md` | 491 |
+| 493 | bootstrap.sh script | `scripts/bootstrap.sh` (new) | — |
+| 494 | doctor.sh script | `scripts/doctor.sh` (new) | — |
+| 495 | Agent compatibility matrix + Mermaid | `README.md` | 491, 492 |
+| 496 | Adoption paths + practical examples | `README.md` | 491, 492, 495 |
+| 497 | Normalize setup docs | `QUICKSTART.md`, `CONTRIBUTING.md`, `README.md` | 493, 494 |
+
+## Execution Strategy: Hybrid
+
+**3 PRs grouped by concern (per AGENTS.md "one concern per PR"):**
+
+### Wave 1: Setup Scripts (parallel agents)
+
+- **Branch**: `feat/bootstrap-doctor-scripts`
+- **Scope**: #493, #494 (independent new files)
+- **Strategy**: Parallel — 2 agents in 1 message create `bootstrap.sh` and `doctor.sh`
+- **Quality gate**: shellcheck, idempotency check, `agents-docs/SCRIPTS.md` update
+
+### Wave 2: README Overhaul (sequential per file conflict)
+
+- **Branch**: `docs/readme-overhaul`
+- **Scope**: #491, #492, #495, #496 (all touch README.md)
+- **Strategy**: Sequential within single PR (all 4 are README content additions)
+- **Quality gate**: markdownlint, mermaid render check, link validation
+
+### Wave 3: Docs Normalization (depends on Wave 1)
+
+- **Branch**: `chore/normalize-setup-docs`
+- **Scope**: #497 (touches QUICKSTART.md, CONTRIBUTING.md, README.md)
+- **Strategy**: Sequential, must wait for Wave 1 PR merged
+- **Quality gate**: markdownlint, no orphaned references to old setup sequence
+
+## Quality Gates
+
+After each wave:
+1. `./scripts/quality_gate.sh` — full local validation
+2. `git push` → CI runs
+3. Monitor `gh run watch` until all green
+4. Auto-fix any failures using `self-fix-loop`
+5. Address any PR review comments
+
+## Agent Coordination Plan
+
+| Wave | Agent | Task |
+|------|-------|------|
+| 1 | general (×2 parallel) | Write `bootstrap.sh` + `doctor.sh` |
+| 1 | shell-script-quality | shellcheck + idempotency tests |
+| 2 | general (sequential) | README content per issue acceptance criteria |
+| 2 | code-review-assistant | Verify markdownlint + mermaid renders |
+| 3 | general | Normalize QUICKSTART/CONTRIBUTING |
+| 5 | github-pr-sentinel | Monitor CI + comments until merged |
 
 ## Actions Queue
 
-1. [x] Fix MD022 markdownlint error in ADR-007 (blank lines around `### Positive`/`### Negative` headings)
-2. [x] Fix MD022 markdownlint error in GOAP_STATE.md (`### PR #419`/`### PR #414`)
-3. [x] Register ADR-007 in `plans/_status.json` (checked by `check-adr-compliance.sh`)
-4. [ ] Verify CI returns to passing after `e3e72d5`, PR #477 auto-resolves
-5. [ ] Monitor next Dependabot run: **Monday June 8, 2026 09:00 UTC** — verify GraphQL auto-merge works end-to-end. Check with `gh pr list --author dependabot --state open` on/after June 8.
+1. [x] GOAP plan written
+2. [ ] **Wave 1**: Create `scripts/bootstrap.sh` + `scripts/doctor.sh` (parallel)
+3. [ ] **Wave 1**: shellcheck + quality gate
+4. [ ] **Wave 1**: Branch `feat/bootstrap-doctor-scripts`, commit, push, PR
+5. [ ] **Wave 1**: Verify all CI checks pass with zero warnings
+6. [ ] **Wave 2**: Implement README hero + 'Why' + compatibility + adoption (sequential)
+7. [ ] **Wave 2**: markdownlint + quality gate
+8. [ ] **Wave 2**: Branch `docs/readme-overhaul`, commit, push, PR
+9. [ ] **Wave 2**: Verify all CI checks pass
+10. [ ] **Wave 3**: Normalize QUICKSTART.md + CONTRIBUTING.md + README.md Quick Start
+11. [ ] **Wave 3**: Branch `chore/normalize-setup-docs`, commit, push, PR
+12. [ ] **Wave 3**: Verify all CI checks pass
+13. [ ] Address all PR review comments across waves
+14. [ ] Close issues 491-497 via PR references (`Fixes #N` in PR body)
+15. [ ] Run `learn` skill, append metrics to `.agents/metrics.jsonl`
 
 ## Blockers
 
 - None
 
-## Deferred
+## Constraints (from AGENTS.md)
 
-- **act CI simulation**: Docker and act binary not installed — local CI simulation unavailable. When Docker becomes available, use `scripts/run_act_local.sh` to test workflows locally before pushing.
-
-## Previous Sessions
-
-### PR #419 (turso-db sync) — MERGED
-
-- All 25/25 CI checks passed, squashed into main
-- See commit `e9d1424` through `9e41ac2`
-
-### PR #414 (WASM size gate) — MERGED
-
-- All 24 CI checks passed, squashed into main
+- Max 500 lines/file, 250/SKILL.md, 200/AGENTS.md
+- PR title: `type(scope): description` (max 150 chars)
+- Commit subject: max 150 chars total lowercase
+- One concern per PR; never commit to main directly
+- Static analysis findings must be triaged before commit
+- Pre-commit hook will run automatically

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-log()  { printf '==> %s\n' "$*"; }
-ok()   { printf '  \u2713 %s\n' "$*"; }
-warn() { printf '  ! %s\n' "$*"; }
+log()  { printf '==> %s\n' "$*"; return 0; }
+ok()   { printf '  \u2713 %s\n' "$*"; return 0; }
+warn() { printf '  ! %s\n' "$*"; return 0; }
 fail() { printf '\n\u2717 %s\n' "$*" >&2; exit 1; }
 
 # --- pre-flight ---

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# bootstrap.sh - Single-command first-time setup for the GitHub AI Agents template.
+# Installs skill symlinks, the pre-commit hook, validates skills, runs the quality gate.
+# Idempotent: safe to re-run. See: scripts/doctor.sh for diagnostics on failure.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+log()  { printf '==> %s\n' "$*"; }
+ok()   { printf '  \u2713 %s\n' "$*"; }
+warn() { printf '  ! %s\n' "$*"; }
+fail() { printf '\n\u2717 %s\n' "$*" >&2; exit 1; }
+
+# --- pre-flight ---
+log "Checking environment"
+command -v git >/dev/null 2>&1 || fail "git not found - install git first"
+[[ -d .git ]] || fail "Run bootstrap.sh from the repository root"
+ok "git present and inside a repository"
+
+# --- symlink support check ---
+SYMLINK_TEST="$(mktemp -u)"
+if ln -sf /dev/null "$SYMLINK_TEST" 2>/dev/null; then
+  rm -f "$SYMLINK_TEST"
+  log "Setting up skills"
+  if ./scripts/setup-skills.sh; then
+    ok "Skills ready"
+  else
+    fail "setup-skills.sh failed - run ./scripts/doctor.sh for diagnostics"
+  fi
+else
+  warn "Symlinks unavailable. On Windows, enable Developer Mode or run inside WSL2."
+  warn "Skills setup will be skipped."
+fi
+
+# --- git hook ---
+log "Installing pre-commit hook"
+HOOK_SRC="scripts/pre-commit-hook.sh"
+HOOK_DST=".git/hooks/pre-commit"
+
+if [[ -f "$HOOK_SRC" ]]; then
+  cp "$HOOK_SRC" "$HOOK_DST"
+  chmod +x "$HOOK_DST"
+  ok "pre-commit hook installed"
+else
+  warn "$HOOK_SRC not found, skipping hook install"
+fi
+
+# --- validate ---
+log "Validating skills"
+if ./scripts/validate-skills.sh >/dev/null 2>&1; then
+  ok "Skills valid"
+else
+  warn "Skills validation reported issues - run ./scripts/doctor.sh for details"
+fi
+
+# --- quality gate ---
+log "Running quality gate"
+if ./scripts/quality_gate.sh; then
+  ok "Quality gate passed"
+  printf '\nBootstrap complete. Repository is ready for AI agent workflows.\n'
+  exit 0
+else
+  printf '\nBootstrap completed with quality gate issues.\n' >&2
+  printf 'Run ./scripts/doctor.sh for environment diagnostics.\n' >&2
+  exit 1
+fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# doctor.sh - Environment diagnostics for the GitHub AI Agents template.
+# Exits 0 when all hard checks pass; exits 1 when any hard check fails.
+# Soft warnings (optional tools missing) do not cause failure.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || { printf 'doctor: cannot cd to repo root: %s\n' "$REPO_ROOT" >&2; exit 1; }
+
+fail=0
+
+pass() { printf '  \u2713 %s\n' "$*"; }
+warn() { printf '  ! %s\n' "$*"; }
+bad()  { printf '  \u2717 %s\n' "$*" >&2; fail=1; }
+sect() { printf '\n==> %s\n' "$*"; }
+
+# ---- Required commands ----
+sect "Required tools"
+for cmd in git bash; do
+  if command -v "$cmd" >/dev/null 2>&1; then
+    pass "$cmd: $(command -v "$cmd")"
+  else
+    bad "$cmd not found"
+  fi
+done
+
+# ---- Optional quality tools ----
+sect "Optional quality tools (needed for quality_gate.sh)"
+for cmd in markdownlint-cli2 shellcheck yamllint; do
+  if command -v "$cmd" >/dev/null 2>&1; then
+    pass "$cmd available"
+  else
+    warn "$cmd not found - quality gate may warn"
+  fi
+done
+
+# ---- Repository state ----
+sect "Repository"
+if [[ -d .git ]]; then
+  pass "Inside a git repository"
+else
+  bad "Not inside a git repository (run from repo root)"
+fi
+
+# ---- Symlink support ----
+sect "Symlink support"
+SYMLINK_TEST="$(mktemp -u)"
+if ln -sf /dev/null "$SYMLINK_TEST" 2>/dev/null; then
+  rm -f "$SYMLINK_TEST"
+  pass "Symlinks supported"
+else
+  bad "Symlinks not supported - Windows without Developer Mode or WSL2"
+fi
+
+# ---- Canonical skills directory ----
+sect "Skills"
+if [[ -d .agents/skills ]]; then
+  pass ".agents/skills directory exists"
+else
+  bad ".agents/skills missing (run setup-skills.sh)"
+fi
+
+# Check expected symlinks
+for link in .claude/skills .qwen/skills; do
+  if [[ -L "$link" ]]; then
+    target="$(readlink "$link")"
+    pass "$link -> $target"
+  elif [[ -d "$link" ]]; then
+    # Directory of symlinks rather than a single symlink is also fine
+    if [[ -n "$(find "$link" -maxdepth 1 -type l 2>/dev/null | head -n 1)" ]]; then
+      pass "$link populated with skill symlinks"
+    else
+      warn "$link exists but contains no symlinks (run setup-skills.sh)"
+    fi
+  elif [[ -e "$link" ]]; then
+    bad "$link exists but is NOT a symlink or skills directory"
+  else
+    warn "$link not present (run setup-skills.sh if you use this tool)"
+  fi
+done
+
+# ---- Git hooks ----
+sect "Git hooks"
+HOOK=".git/hooks/pre-commit"
+if [[ -f "$HOOK" ]]; then
+  if [[ -x "$HOOK" ]]; then
+    pass "pre-commit hook installed and executable"
+  else
+    bad "pre-commit hook exists but is NOT executable (run: chmod +x $HOOK)"
+  fi
+else
+  bad "pre-commit hook missing (run: bootstrap.sh)"
+fi
+
+# ---- Core files ----
+sect "Core files"
+for f in AGENTS.md QUICKSTART.md; do
+  if [[ -f "$f" ]]; then
+    pass "$f present"
+  else
+    bad "$f missing"
+  fi
+done
+
+# ---- Final result ----
+printf '\n'
+if [[ $fail -eq 0 ]]; then
+  printf '\u2713 doctor: all checks passed.\n'
+  exit 0
+else
+  printf '\u2717 doctor: one or more checks failed. Fix the issues above, then re-run.\n' >&2
+  exit 1
+fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -9,10 +9,10 @@ cd "$REPO_ROOT" || { printf 'doctor: cannot cd to repo root: %s\n' "$REPO_ROOT" 
 
 fail=0
 
-pass() { printf '  \u2713 %s\n' "$*"; }
-warn() { printf '  ! %s\n' "$*"; }
-bad()  { printf '  \u2717 %s\n' "$*" >&2; fail=1; }
-sect() { printf '\n==> %s\n' "$*"; }
+pass() { printf '  \u2713 %s\n' "$*"; return 0; }
+warn() { printf '  ! %s\n' "$*"; return 0; }
+bad()  { printf '  \u2717 %s\n' "$*" >&2; fail=1; return 1; }
+sect() { printf '\n==> %s\n' "$*"; return 0; }
 
 # ---- Required commands ----
 sect "Required tools"

--- a/tests/bootstrap-doctor.bats
+++ b/tests/bootstrap-doctor.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Tests for scripts/bootstrap.sh and scripts/doctor.sh
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    cd "$REPO_ROOT"
+}
+
+# ---------- bootstrap.sh ----------
+
+@test "bootstrap.sh exists and is executable" {
+    [ -x "./scripts/bootstrap.sh" ]
+}
+
+@test "bootstrap.sh has bash shebang" {
+    head -1 ./scripts/bootstrap.sh | grep -q "^#!/usr/bin/env bash$"
+}
+
+@test "bootstrap.sh passes shellcheck" {
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        skip "shellcheck not installed"
+    fi
+    run shellcheck ./scripts/bootstrap.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "bootstrap.sh has set -euo pipefail" {
+    grep -q '^set -euo pipefail$' ./scripts/bootstrap.sh
+}
+
+@test "bootstrap.sh references doctor.sh on failure" {
+    grep -q 'doctor.sh' ./scripts/bootstrap.sh
+}
+
+@test "bootstrap.sh uses REPO_ROOT detection pattern" {
+    grep -q 'REPO_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE\[0\]}")/.." && pwd)"' \
+        ./scripts/bootstrap.sh
+}
+
+# ---------- doctor.sh ----------
+
+@test "doctor.sh exists and is executable" {
+    [ -x "./scripts/doctor.sh" ]
+}
+
+@test "doctor.sh has bash shebang" {
+    head -1 ./scripts/doctor.sh | grep -q "^#!/usr/bin/env bash$"
+}
+
+@test "doctor.sh passes shellcheck" {
+    if ! command -v shellcheck >/dev/null 2>&1; then
+        skip "shellcheck not installed"
+    fi
+    run shellcheck ./scripts/doctor.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "doctor.sh uses REPO_ROOT detection pattern" {
+    grep -q 'REPO_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE\[0\]}")/.." && pwd)"' \
+        ./scripts/doctor.sh
+}
+
+@test "doctor.sh checks for required tools" {
+    grep -q 'Required tools' ./scripts/doctor.sh
+    grep -q 'for cmd in git bash' ./scripts/doctor.sh
+}
+
+@test "doctor.sh checks symlink support" {
+    grep -q 'Symlink support' ./scripts/doctor.sh
+}
+
+@test "doctor.sh checks for .agents/skills directory" {
+    grep -q '.agents/skills' ./scripts/doctor.sh
+}
+
+@test "doctor.sh checks for pre-commit hook" {
+    grep -q '.git/hooks/pre-commit' ./scripts/doctor.sh
+}
+
+@test "doctor.sh detects missing pre-commit hook with non-zero exit" {
+    HOOK=".git/hooks/pre-commit"
+    BACKUP=""
+    if [ -f "$HOOK" ]; then
+        BACKUP="$(mktemp)"
+        cp "$HOOK" "$BACKUP"
+        rm -f "$HOOK"
+    fi
+
+    run ./scripts/doctor.sh
+
+    if [ -n "$BACKUP" ]; then
+        cp "$BACKUP" "$HOOK"
+        chmod +x "$HOOK"
+        rm -f "$BACKUP"
+    fi
+
+    [ "$status" -ne 0 ]
+}
+
+@test "doctor.sh prints structured pass/fail messages" {
+    run ./scripts/doctor.sh
+    # Either pass or fail, output should include section headers
+    echo "$output" | grep -q '==>'
+}


### PR DESCRIPTION
## Summary

Implements **#493** and **#494** with bundled BATS tests.

### scripts/bootstrap.sh (#493)
Single-command first-time setup that collapses the 4-step manual sequence into one deterministic command.

- Pre-flight: verifies `git` and that user is inside a git repo
- Symlink test: warns and skips skills setup on Windows-without-Developer-Mode
- Runs `setup-skills.sh`, installs `pre-commit` hook, runs `validate-skills.sh`, then `quality_gate.sh`
- Idempotent — safe to re-run
- Routes users to `doctor.sh` on any failure

### scripts/doctor.sh (#494)
Structured environment diagnostics with explicit pass/warn/fail per check.

- Required tools: `git`, `bash`
- Optional quality tools: `markdownlint-cli2`, `shellcheck`, `yamllint` (warn only, never fail)
- Repository state, symlink support, `.agents/skills` presence, expected CLI symlinks
- Pre-commit hook installed + executable
- Core files: `AGENTS.md`, `QUICKSTART.md`
- Exits `0` on clean env, `1` on any hard failure

## Verification

- `shellcheck scripts/bootstrap.sh scripts/doctor.sh` → clean
- `bats tests/bootstrap-doctor.bats` → 16/16 pass
- `./scripts/quality_gate.sh` → all green
- `./scripts/doctor.sh` exercised locally; correctly detects missing pre-commit hook

## Files

- `scripts/bootstrap.sh` (new, executable)
- `scripts/doctor.sh` (new, executable)
- `tests/bootstrap-doctor.bats` (new, 16 tests)
- `agents-docs/SCRIPTS.md` (registered both scripts in core table)
- `plans/GOAP_STATE.md` (orchestration plan for issue batch)

## Acceptance criteria

#493:
- [x] `scripts/bootstrap.sh` exists and is executable
- [x] Idempotent
- [x] Symlink failure → actionable warning, not crash
- [x] Missing `pre-commit-hook.sh` → warning, not crash
- [x] Passes `shellcheck`

#494:
- [x] `scripts/doctor.sh` exists and is executable
- [x] Exits 0 clean, 1 on hard failure; optional tools only warn
- [x] Passes `shellcheck`
- [x] `bootstrap.sh` points users to `doctor.sh` on failure

QUICKSTART.md updates land in #497 follow-up PR (which depends on these scripts existing).

Closes #493
Closes #494