### PR TITLE
🛡️ Sentinel: [HIGH] Harden command categorization against obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -105,3 +105,8 @@
 **Vulnerability:** Command categorization logic used simple substring matching, which led to false positives (e.g., \"mkdir farm\" flagged for \"rm\") and was vulnerable to obfuscation (e.g., \"r\"\"m\"). An initial fix using strict whitespace-only word boundaries introduced detection bypasses for commands adjacent to shell metacharacters (e.g., \"(rm)\" or \"rm;ls\").
 **Learning:** Obfuscation via quotes and backslashes is a common bypass for keyword-based filters. Word-boundary detection must account for the full set of shell metacharacters that can delimit commands, not just whitespace.
 **Prevention:** Normalize command strings by stripping quotes and backslashes before categorization. Use a robust regex boundary \`(^|[[:space:]]|[\\|&;()<>])\` to ensure keywords are detected even when embedded in complex shell expressions while avoiding partial-word matches.
+
+## 2026-06-10 - Command Categorization Bypass via Shell Metacharacters
+**Vulnerability:** Command categorization logic could be bypassed by using shell metacharacters like backticks (`` ` ``) or dollar signs (`$`) for command substitution (e.g., `` `rm` ``), as normalization only stripped quotes and backslashes.
+**Learning:** Obfuscation and substitution are common bypasses for keyword-based security filters. Normalization must account for all shell metacharacters that can wrap or precede commands.
+**Prevention:** Normalize all command input by stripping a comprehensive set of shell metacharacters (quotes, backslashes, backticks, dollar signs, braces, parentheses, brackets) before keyword matching. Standardize word-boundary regexes to include separators like commas for bracket expansion.

--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -25,11 +25,13 @@ categorize_command() {
     local cmd_lower
     # Security: Use printf for safe variable expansion and to prevent option injection.
     # Normalize input by removing common shell escapes/quotes and converting to lowercase.
-    cmd_lower=$(printf "%s\n" "$cmd" | tr -d "'\"\\\\" | tr '[:upper:]' '[:lower:]')
+    # Strips metacharacters used for obfuscation: quotes, backslashes, backticks,
+    # dollar signs, braces, parentheses, and brackets.
+    cmd_lower=$(printf "%s\n" "$cmd" | tr -d "'\"\\\\\`\$(){}[]" | tr '[:upper:]' '[:lower:]')
 
-    # Regex for word boundaries including common shell metacharacters
-    local boundary="(^|[[:space:]]|[\|&;()<>])"
-    local end_boundary="($|[[:space:]]|[\|&;()<>])"
+    # Regex for word boundaries including common shell metacharacters and commas
+    local boundary="(^|[[:space:]]|[\|&;()<>|,])"
+    local end_boundary="($|[[:space:]]|[\|&;()<>|,])"
 
     # Check custom dangerous patterns first (E3)
     for pattern in "${DANGEROUS_PATTERNS[@]:-}"; do


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command categorization bypass via shell metacharacters and comma-separated lists.
🎯 Impact: Malicious commands in documentation could bypass security filters using substitution (e.g., `` `rm` ``) or bracket expansion (e.g., `{rm,ls}`).
🔧 Fix: Normalize command input to strip a wider range of shell metacharacters and refined word boundaries to include commas.
✅ Verification: Verified with a dedicated test script and validated via `./scripts/quality_gate.sh`.

---
*PR created automatically by Jules for task [13579506423089862287](https://jules.google.com/task/13579506423089862287) started by @d-o-hub*