### PR TITLE
fix(security): 🛡️ Sentinel: harden command categorization against eval/exec

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -110,3 +110,8 @@
 **Vulnerability:** Command categorization logic could be bypassed by using shell metacharacters like backticks (`` ` ``) or dollar signs (`$`) for command substitution (e.g., `` `rm` ``), as normalization only stripped quotes and backslashes.
 **Learning:** Obfuscation and substitution are common bypasses for keyword-based security filters. Normalization must account for all shell metacharacters that can wrap or precede commands.
 **Prevention:** Normalize all command input by stripping a comprehensive set of shell metacharacters (quotes, backslashes, backticks, dollar signs, braces, parentheses, brackets) before keyword matching. Standardize word-boundary regexes to include separators like commas for bracket expansion.
+
+## 2026-06-15 - Command Categorization Bypass via eval and exec
+**Vulnerability:** The command categorization logic did not explicitly flag `eval` and `exec` as dangerous keywords, allowing them to be used to execute arbitrary strings or replace the current shell process, potentially bypassing security filters that only look for direct command names like `rm`.
+**Learning:** Administrative and meta-execution commands like `eval` and `exec` are common primitives for bypassing security controls or escalating privileges in restricted shell environments.
+**Prevention:** Explicitly include `eval` and `exec` in the `DANGEROUS_KEYWORDS` list to ensure they are flagged for manual review alongside destructive commands like `rm`.

--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Default categories (can be overridden in .command-verify.conf)
 SAFE_KEYWORDS="${SAFE_KEYWORDS:-build:test:lint:check:status:list:help:version:describe:doc:info:show:get}"
 CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace}"
-DANGEROUS_KEYWORDS="${DANGEROUS_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:terminate}"
+DANGEROUS_KEYWORDS="${DANGEROUS_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:terminate:eval:exec}"
 
 # Custom patterns for categories (E3)
 SAFE_PATTERNS=()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The command categorization logic did not explicitly flag `eval` and `exec` as dangerous keywords.
🎯 Impact: These primitives can be used to execute arbitrary strings or replace the current shell process, potentially bypassing security filters that only look for direct command names like `rm`.
🔧 Fix: Added `eval` and `exec` to the `DANGEROUS_KEYWORDS` list in `scripts/lib/command-categories.sh`.
✅ Verification: Verified using a test script that `eval` and `exec` are now correctly categorized as `dangerous`. Confirmed that `scripts/quality_gate.sh` and the repository test suite pass.

---
*PR created automatically by Jules for task [4045388580144983129](https://jules.google.com/task/4045388580144983129) started by @d-o-hub*