### PR TITLE
fix(ci): allow required checks to run on auto-generated PRs

### DIFF
--- a/.github/workflows/ci-and-labels.yml
+++ b/.github/workflows/ci-and-labels.yml
@@ -201,7 +201,8 @@ jobs:
     needs: [labels, quality-gate, test]
     if: |
       always() &&
-      github.actor != 'dependabot[bot]'
+      github.actor != 'dependabot[bot]' &&
+      github.event_name != 'pull_request'
     concurrency:
       group: ci-status-update
       cancel-in-progress: true
@@ -254,7 +255,7 @@ jobs:
 
           PR_BRANCH="ci/status-update"
           git checkout -b "$PR_BRANCH" 2>/dev/null || git checkout "$PR_BRANCH"
-          git commit -m "ci: update ci status artifacts [skip ci]"
+          git commit -m "ci: update ci status artifacts"
           git push origin --force -- "$PR_BRANCH"
 
           # Find-or-create the canonical CI status PR
@@ -283,9 +284,18 @@ jobs:
           # Auto-merge via squash; --admin bypasses required checks (ci/status-update
           # is itself one of them, so --auto would deadlock); [skip ci] prevents
           # the merge commit from re-triggering this workflow.
-          gh pr merge "$NEW_PR" \
+          # NOTE: If --admin fails (e.g. GITHUB_TOKEN lacks repo admin), the PR
+          # stays open and required checks will run on subsequent pushes, allowing
+          # normal merge once checks pass.
+          if gh pr merge "$NEW_PR" \
             --squash \
             --subject "ci: update ci status artifacts [skip ci]" \
             --admin \
-            --delete-branch=false \
-          || printf "Merge skipped or already merged for PR #%s\n" "$NEW_PR"
+            --delete-branch=false; then
+            printf "Auto-merged PR #%s\n" "$NEW_PR"
+          else
+            EXIT_CODE=$?
+            printf "WARNING: Auto-merge failed for PR #%s (exit %d)\n" \
+              "$NEW_PR" "$EXIT_CODE" >&2
+            printf "PR will be merged once required checks pass\n"
+          fi

--- a/.github/workflows/update-llms-txt.yml
+++ b/.github/workflows/update-llms-txt.yml
@@ -38,7 +38,7 @@ jobs:
             echo "No changes to llms.txt or llms-full.txt"
             exit 0
           fi
-          git commit -m "ci: regenerate llms.txt and llms-full.txt [skip ci]"
+          git commit -m "ci: regenerate llms.txt and llms-full.txt"
           git push -f origin "$BRANCH"
           # Find-or-create the canonical PR for this branch
           EXISTING_PR=$(gh pr list --head "$BRANCH" --state open \
@@ -55,11 +55,17 @@ jobs:
           fi
           # Auto-merge via squash; --admin bypasses required checks to avoid deadlock;
           # [skip ci] prevents the merge commit from re-triggering this workflow.
-          gh pr merge "$NEW_PR" \
+          if gh pr merge "$NEW_PR" \
             --squash \
             --subject "ci: regenerate llms.txt and llms-full.txt [skip ci]" \
             --admin \
-            --delete-branch=false \
-          || printf "Merge skipped or already merged for PR #%s\n" "$NEW_PR"
+            --delete-branch=false; then
+            printf "Auto-merged PR #%s\n" "$NEW_PR"
+          else
+            EXIT_CODE=$?
+            printf "WARNING: Auto-merge failed for PR #%s (exit %d)\n" \
+              "$NEW_PR" "$EXIT_CODE" >&2
+            printf "PR will be merged once required checks pass\n"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/test-update-llms-txt-workflow.bats
+++ b/tests/test-update-llms-txt-workflow.bats
@@ -4,8 +4,9 @@
     grep -q "BRANCH=\"auto/regenerate-llms-txt\"" .github/workflows/update-llms-txt.yml
 }
 
-@test "llms-txt workflow uses skip ci in commit message" {
-    grep -q 'commit -m "ci: regenerate llms.txt and llms-full.txt \[skip ci\]"' .github/workflows/update-llms-txt.yml
+@test "llms-txt workflow omits skip ci from branch commit (allows checks to run)" {
+    grep -q 'commit -m "ci: regenerate llms.txt and llms-full.txt"' .github/workflows/update-llms-txt.yml
+    ! grep -q 'commit -m "ci: regenerate llms.txt and llms-full.txt \[skip ci\]"' .github/workflows/update-llms-txt.yml
 }
 
 @test "llms-txt workflow uses skip ci in merge subject" {

--- a/tests/test-workflow-logic.bats
+++ b/tests/test-workflow-logic.bats
@@ -8,8 +8,13 @@
     grep -q "gh pr create" .github/workflows/ci-and-labels.yml
 }
 
-@test "workflow includes skip ci in commit message" {
-    grep -q "commit -m \"ci: update ci status artifacts \\[skip ci\\]\"" .github/workflows/ci-and-labels.yml
+@test "workflow omits skip ci from branch commit (allows checks to run)" {
+    grep -q "commit -m \"ci: update ci status artifacts\"" .github/workflows/ci-and-labels.yml
+    ! grep -q "commit -m \"ci: update ci status artifacts \\[skip ci\\]\"" .github/workflows/ci-and-labels.yml
+}
+
+@test "workflow includes skip ci only in squash merge subject" {
+    grep -q '\-\-subject "ci: update ci status artifacts \[skip ci\]"' .github/workflows/ci-and-labels.yml
 }
 
 @test "workflow uses dynamic base for PR creation" {
@@ -41,4 +46,8 @@
 
 @test "workflow has ci-status label step" {
     grep -q "gh label create ci-status" .github/workflows/ci-and-labels.yml
+}
+
+@test "update-ci-status job skips on pull_request events" {
+    grep -q "github.event_name != 'pull_request'" .github/workflows/ci-and-labels.yml
 }


### PR DESCRIPTION
## Problem

Auto-generated PRs (ci/status-update, auto/regenerate-llms-txt) were created with `[skip ci]` in the branch commit message, which prevented required status checks from running. The `--admin` merge flag was supposed to bypass this, but `GITHUB_TOKEN` lacks repo admin permissions, causing the merge to fail silently.

## Root Cause

1. `[skip ci]` in the branch commit skips both `push` and `pull_request` events — required checks never reported
2. `gh pr merge --admin` requires admin permissions the token doesn't have
3. `|| printf` fallback silently swallowed the merge failure

## Fix

- Remove `[skip ci]` from branch commits so required checks run on the PR
- Add `github.event_name != 'pull_request'` guard to prevent the workflow from re-creating the CI status PR when triggered by its own PR
- Replace silent `\|\| printf` with explicit `if/else` error handling

## Files Changed

- `.github/workflows/ci-and-labels.yml`
- `.github/workflows/update-llms-txt.yml`