### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden command categorization regex

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** Limited coverage of destructive commands, interpreters, and sensitive directories allowed potential bypasses of agent security controls. Specifically, variant commands like `mkfs.ext4` could bypass detection if the regex was too strict.
 **Learning:** Security keyword lists and forbidden directory denylists must be comprehensive and account for common variations and infrastructure components. Regex boundaries must allow for alphanumeric suffixes and dots to catch command variants while avoiding false positives from script names.
 **Prevention:** Periodically review and expand `DESTRUCTIVE_KEYWORDS`, `INTERPRETER_KEYWORDS`, and `FORBIDDEN_OUTPUT_DIRS`. Use broad regex boundaries `[a-z0-9.]*` for command matching while strictly excluding known script extensions.
+
+## 2026-07-15 - Hardening Keyword Matching Against False Positives
+
+**Vulnerability:** Greedy suffix matching (`[a-z0-9.]*`) after security keywords caused unrelated commands to be flagged as dangerous (e.g., `nslookup` matching `node`, `google` matching `go`, `shout` matching `sh`).
+**Learning:** Command variant matching must distinguish between legitimate versioned binaries/subcommands (which typically start with a digit or dot) and unrelated words that happen to contain the keyword as a prefix.
+**Prevention:** Use constrained suffix patterns like `([.][a-z0-9]+|[0-9][a-z0-9.]*)?` instead of broad alphanumeric globs when matching command variants to ensure the suffix belongs to a version or extension of the intended command.

--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -87,11 +87,12 @@ categorize_command() {
     done
 
     # Check destructive keywords with broad boundaries (to catch mkfs.ext4)
-    # Allows optional trailing alphanumeric chars and dots immediately after the keyword.
-    local destructive_regex="${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})[a-z0-9.]*${broad_end_boundary}"
+    # Allows optional trailing alphanumeric chars and dots immediately after the keyword,
+    # but requires the suffix to start with a digit or dot to prevent matching unrelated words.
+    local destructive_regex="${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})([.][a-z0-9]+|[0-9][a-z0-9.]*)?${broad_end_boundary}"
     if [[ "$cmd_lower" =~ $destructive_regex ]]; then
         # Negative lookahead alternative: ensure it is not a script file like rm.sh
-        if [[ "$cmd_lower" =~ ${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})[a-z0-9.]*\.(sh|py|pl|rb|js) ]]; then
+        if [[ "$cmd_lower" =~ ${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})([.][a-z0-9]+|[0-9][a-z0-9.]*)?\.(sh|py|pl|rb|js) ]]; then
              : # Matches script name, continue
         else
              printf "dangerous\n"
@@ -100,11 +101,12 @@ categorize_command() {
     fi
 
     # Check interpreter keywords with broad boundaries (to catch python3.11)
-    # Allows optional trailing alphanumeric chars and dots immediately after the keyword.
-    local interpreter_regex="${boundary}(${INTERPRETER_KEYWORDS//:/|})[a-z0-9.]*${broad_end_boundary}"
+    # Allows optional trailing alphanumeric chars and dots immediately after the keyword,
+    # but requires the suffix to start with a digit or dot to prevent matching unrelated words.
+    local interpreter_regex="${boundary}(${INTERPRETER_KEYWORDS//:/|})([.][a-z0-9]+|[0-9][a-z0-9.]*)?${broad_end_boundary}"
     if [[ "$cmd_lower" =~ $interpreter_regex ]]; then
         # Negative lookahead alternative: ensure it is not a script file like python3.11.sh
-        if [[ "$cmd_lower" =~ ${boundary}(${INTERPRETER_KEYWORDS//:/|})[a-z0-9.]*\.(sh|py|pl|rb|js) ]]; then
+        if [[ "$cmd_lower" =~ ${boundary}(${INTERPRETER_KEYWORDS//:/|})([.][a-z0-9]+|[0-9][a-z0-9.]*)?\.(sh|py|pl|rb|js) ]]; then
              : # Matches script name, continue
         else
              printf "dangerous\n"

--- a/tests/test-security-categorization.bats
+++ b/tests/test-security-categorization.bats
@@ -45,3 +45,28 @@ setup() {
     run categorize_command "Install dependencies"
     [ "$output" = "conditional" ]
 }
+
+@test "harden-command-categorization: prevents false positives for unrelated words containing keywords" {
+    run categorize_command "nslookup google.com"
+    [ "$output" = "unknown" ]
+
+    run categorize_command "dig google.com"
+    [ "$output" = "unknown" ]
+
+    run categorize_command "shout something"
+    [ "$output" = "unknown" ]
+
+    run categorize_command "google-chrome"
+    [ "$output" = "unknown" ]
+}
+
+@test "harden-command-categorization: still detects valid versioned commands" {
+    run categorize_command "python3.11 script.py"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "node16 index.js"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "mkfs.ext4 /dev/sda1"
+    [ "$output" = "dangerous" ]
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Greedy suffix matching in command categorization caused false positives for unrelated commands (e.g., 'nslookup' matched 'node', 'google' matched 'go').
🎯 Impact: Unnecessary security warnings and blocked commands for safe operations, leading to friction and potential alert fatigue.
🔧 Fix: Constrained the command suffix regex to only allow digits or dots immediately following a keyword, ensuring only legitimate versioned commands (like 'python3.11' or 'mkfs.ext4') are matched.
✅ Verification: Added new BATS tests in 'tests/test-security-categorization.bats' covering both false positive prevention and continued detection of valid versioned commands. Ran full security test suite.

---
*PR created automatically by Jules for task [17352771669430747344](https://jules.google.com/task/17352771669430747344) started by @d-o-hub*