### PR TITLE
fix: harden command categorization regex and expand keywords

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** Limited coverage of destructive commands, interpreters, and sensitive directories allowed potential bypasses of agent security controls. Specifically, variant commands like `mkfs.ext4` could bypass detection if the regex was too strict.
 **Learning:** Security keyword lists and forbidden directory denylists must be comprehensive and account for common variations and infrastructure components. Regex boundaries must allow for alphanumeric suffixes and dots to catch command variants while avoiding false positives from script names.
 **Prevention:** Periodically review and expand `DESTRUCTIVE_KEYWORDS`, `INTERPRETER_KEYWORDS`, and `FORBIDDEN_OUTPUT_DIRS`. Use broad regex boundaries `[a-z0-9.]*` for command matching while strictly excluding known script extensions.
+
+## 2026-06-29 - Hardened Suffix Pattern for Command Categorization
+
+**Vulnerability:** Greedy suffix matching `[a-z0-9.]*` caused false positives on common words (e.g., `show` matched `sh`, `google` matched `go`).
+**Learning:** Suffix patterns for command matching must distinguish between versioned/hyphenated variants and unrelated words. A more restrictive pattern `([.][a-z0-9]+|[0-9-][a-z0-9.]*)?` allows for `python3.11`, `mkfs.ext4`, and `nc-traditional` while rejecting words where the keyword is just a prefix.
+**Prevention:** Use structured suffix regexes that require a dot, digit, or hyphen immediately following the keyword when matching command variants.

--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -6,13 +6,13 @@ set -euo pipefail
 # Security Hardening: 2026-06-20 - Prevented keyword merging bypasses.
 # Default categories (can be overridden in .command-verify.conf)
 SAFE_KEYWORDS="${SAFE_KEYWORDS:-build:test:lint:check:status:list:help:version:describe:doc:info:show:get:ls:cat:echo:grep:find:pwd:diff:cd:head:tail:sort:uniq:wc:git:log:pgrep:type:which:df:du:free:top:ps:history}"
-CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl}"
+CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl:ssh-keygen:openssl:gpg}"
 # Destructive and administrative commands (strict boundaries)
-DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill}"
+DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:killall:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill:sed:truncate:unlink:tee:-f:-y}"
 # Language interpreters (broad boundaries to catch versioned ones like python3.11)
-INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv}"
+INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:pip3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv}"
 # Networking tools (strict boundaries to avoid false positives like curl.sh)
-NETWORK_KEYWORDS="${NETWORK_KEYWORDS:-curl:wget:nc:netcat:nmap:ssh:scp:sftp:rsync:socat}"
+NETWORK_KEYWORDS="${NETWORK_KEYWORDS:-curl:wget:nc:netcat:nmap:ssh:scp:sftp:rsync:socat:nslookup:dig:host:nc.openbsd:nc.traditional}"
 
 # Custom patterns for categories (E3)
 SAFE_PATTERNS=()
@@ -87,11 +87,12 @@ categorize_command() {
     done
 
     # Check destructive keywords with broad boundaries (to catch mkfs.ext4)
-    # Allows optional trailing alphanumeric chars and dots immediately after the keyword.
-    local destructive_regex="${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})[a-z0-9.]*${broad_end_boundary}"
+    # Allows optional trailing alphanumeric chars, dots, and hyphens immediately after the keyword.
+    # Security: Use a hardened suffix pattern to avoid false positives from unrelated words.
+    local destructive_regex="${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
     if [[ "$cmd_lower" =~ $destructive_regex ]]; then
         # Negative lookahead alternative: ensure it is not a script file like rm.sh
-        if [[ "$cmd_lower" =~ ${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})[a-z0-9.]*\.(sh|py|pl|rb|js) ]]; then
+        if [[ "$cmd_lower" =~ ${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?\.(sh|py|pl|rb|js) ]]; then
              : # Matches script name, continue
         else
              printf "dangerous\n"
@@ -100,11 +101,12 @@ categorize_command() {
     fi
 
     # Check interpreter keywords with broad boundaries (to catch python3.11)
-    # Allows optional trailing alphanumeric chars and dots immediately after the keyword.
-    local interpreter_regex="${boundary}(${INTERPRETER_KEYWORDS//:/|})[a-z0-9.]*${broad_end_boundary}"
+    # Allows optional trailing alphanumeric chars, dots, and hyphens immediately after the keyword.
+    # Security: Use a hardened suffix pattern to avoid false positives from unrelated words.
+    local interpreter_regex="${boundary}(${INTERPRETER_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
     if [[ "$cmd_lower" =~ $interpreter_regex ]]; then
         # Negative lookahead alternative: ensure it is not a script file like python3.11.sh
-        if [[ "$cmd_lower" =~ ${boundary}(${INTERPRETER_KEYWORDS//:/|})[a-z0-9.]*\.(sh|py|pl|rb|js) ]]; then
+        if [[ "$cmd_lower" =~ ${boundary}(${INTERPRETER_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?\.(sh|py|pl|rb|js) ]]; then
              : # Matches script name, continue
         else
              printf "dangerous\n"
@@ -112,11 +114,12 @@ categorize_command() {
         fi
     fi
 
-    # Check network keywords with strict boundaries
-    local network_regex="${boundary}(${NETWORK_KEYWORDS//:/|})${end_boundary}"
+    # Check network keywords with broad boundaries
+    # Allows optional trailing alphanumeric chars, dots, and hyphens immediately after the keyword.
+    local network_regex="${boundary}(${NETWORK_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
     if [[ "$cmd_lower" =~ $network_regex ]]; then
         # Ensure it is not followed by .sh or .py which indicates a script name
-        if [[ "$cmd_lower" =~ ${boundary}(${NETWORK_KEYWORDS//:/|})\.(sh|py|pl|rb|js) ]]; then
+        if [[ "$cmd_lower" =~ ${boundary}(${NETWORK_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?\.(sh|py|pl|rb|js) ]]; then
             : # Likely a script name, ignore
         else
             printf "dangerous\n"


### PR DESCRIPTION
Harden command categorization regex to prevent false positives while maintaining coverage for versioned commands. Expand security keywords across destructive, network, and conditional categories.

---
*PR created automatically by Jules for task [10554506004984035881](https://jules.google.com/task/10554506004984035881) started by @d-o-hub*