### PR TITLE
fix(security): prevent path validation bypass for nested forbidden paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,9 @@
 **Vulnerability:** Gaps in forbidden path denylists and command categorization allowed potential access to cloud provider credentials (e.g., .aws, .kube) and execution of system-critical tools (e.g., firewall-cmd, crontab).
 **Learning:** Security boundaries must be frequently audited to include infrastructure-specific configuration files and administrative utilities that could be used for persistence or lateral movement.
 **Prevention:** Expand `FORBIDDEN_PATHS` and command keyword lists to cover ecosystem-specific secrets and administrative tools.
+
+## 2026-07-04 - Fix Path Validation Bypass for Nested Forbidden Paths
+
+**Vulnerability:** The `validate_safe_path` function only checked if the top-level component of a path was in `FORBIDDEN_PATHS`, allowing bypasses for nested sensitive files (e.g., `subdir/.env`).
+**Learning:** Security validation must be recursive or iterative over all user-controllable path components. Checking only the root of a relative path is insufficient when subdirectories are allowed.
+**Prevention:** Always iterate through all parts of a resolved path when checking against a denylist of forbidden files or directories.

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -86,10 +86,10 @@ def validate_safe_path(
         ) from None
 
     if check_forbidden and candidate != base_resolved:
-        top_level = candidate.relative_to(base_resolved).parts[0]
-        if top_level in FORBIDDEN_PATHS:
-            raise PathValidationError(
-                f"--{param_name} targets a forbidden path: {top_level}"
-            )
+        for part in candidate.relative_to(base_resolved).parts:
+            if part in FORBIDDEN_PATHS:
+                raise PathValidationError(
+                    f"--{param_name} targets a forbidden path: {part}"
+                )
 
     return candidate

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -54,6 +54,11 @@ def test_validate_safe_path_forbidden(tmp_path):
         with pytest.raises(PathValidationError):
             validate_safe_path(f"{forbidden}/file.txt", base, "test", check_forbidden=True)
 
+    # Test nested forbidden path
+    (base / "subdir").mkdir()
+    with pytest.raises(PathValidationError):
+        validate_safe_path("subdir/.env", base, "test", check_forbidden=True)
+
 
 def test_validate_safe_path_symlink_escape(tmp_path):
     base = tmp_path / "repo"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path validation bypass allowing access to nested forbidden files/directories.
🎯 Impact: An attacker or a misconfigured agent could read/write sensitive files (like `.env` or `.git` contents) by nesting them in an allowed subdirectory, bypassing the top-level-only check.
🔧 Fix: Updated `validate_safe_path` in `scripts/lib/paths.py` to iterate through all path parts and check each against `FORBIDDEN_PATHS`.
✅ Verification: Added a test case in `tests/test_paths.py` that specifically attempts to access `subdir/.env` and verifies it is blocked. Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [10816202537760006609](https://jules.google.com/task/10816202537760006609) started by @d-o-hub*