### PR TITLE
fix(security): harden command keywords and forbidden paths

### DIFF
--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 # Security Hardening: 2026-06-20 - Prevented keyword merging bypasses.
 # Default categories (can be overridden in .command-verify.conf)
 SAFE_KEYWORDS="${SAFE_KEYWORDS:-build:test:lint:check:status:list:help:version:describe:doc:info:show:get:ls:cat:echo:grep:find:pwd:diff:cd:head:tail:sort:uniq:wc:git:log:pgrep:type:which:df:du:free:top:ps:history}"
-CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl:ssh-keygen:openssl:gpg:mv:cp:ln:link:patch:tar:zip:unzip:gzip:gunzip:bzip2:xz}"
+CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl:ssh-keygen:openssl:gpg:mv:cp:ln:link:patch:tar:zip:unzip:gzip:gunzip:bzip2:xz:make:touch:gh:xargs}"
 # Destructive and administrative commands (strict boundaries)
 DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:killall:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill:sed:truncate:unlink:tee:parted:fdisk:gdisk:sfdisk:wipe:srm:badblocks:alias:unalias:iptables:nft:ufw:firewall-cmd:crontab:-f:-y}"
 # Language interpreters (broad boundaries to catch versioned ones like python3.11)
-INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:pip3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv:lua}"
+INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:pip3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv:lua:awk}"
 # Networking tools (strict boundaries to avoid false positives like curl.sh)
 NETWORK_KEYWORDS="${NETWORK_KEYWORDS:-curl:wget:nc:netcat:nmap:ssh:scp:sftp:rsync:socat:nslookup:dig:host:nc.openbsd:nc.traditional:telnet:ftp:tftp:ssh-add:ssh-agent:ncat:tcpdump:wireshark:tshark:aria2c:lynx:links:elinks}"
 # Script extensions treated as safe — a keyword followed by one of these is a script, not a bare command

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -54,6 +54,10 @@ FORBIDDEN_PATHS = frozenset({
     "LICENSE",
     "VERSION",
     ".secrets",
+    ".env.local",
+    ".env.development",
+    ".env.test",
+    ".env.production",
 })
 
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Gaps in command categorization and forbidden path lists allowed potential execution of powerful tools (make, gh, awk) and access to environment-specific secrets (.env.local).
🎯 Impact: An agent could inadvertently execute dangerous commands or expose sensitive environment variables if these tools and paths were not restricted.
🔧 Fix: Expanded the restricted keyword lists in `command-categories.sh` and the forbidden path list in `paths.py`.
✅ Verification: Ran `PYTHONPATH=$(pwd)/scripts/lib pytest tests/test_paths.py` and `npx bats tests/test-security-categorization.bats`. Verified new keywords and paths with custom test scripts.

---
*PR created automatically by Jules for task [16221418001037965927](https://jules.google.com/task/16221418001037965927) started by @d-o-hub*