### PR TITLE
fix(security): harden command categorization and path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,9 @@
 **Vulnerability:** Command strings containing both a dangerous command (e.g., \`rm -rf /\`) and a safe-looking script name (e.g., \`rm.sh\`) were incorrectly exempt from dangerous categorization. This occurred because a single positive script-pattern match would short-circuit the entire validation logic.
 **Learning:** Security validation of command strings must be exhaustive. If a command string contains multiple occurrences of a keyword, every occurrence must be validated against safety patterns. A single "safe" instance cannot be allowed to mask other dangerous instances in the same string.
 **Prevention:** Use iterative matching (e.g., a \`while\` loop with \`BASH_REMATCH\`) to ensure every keyword instance in a command string is inspected. If any instance fails the safety check, the entire string must be treated as dangerous.
+
+## 2026-07-06 - Hardening Command Regex and Remote Helpers
+
+**Vulnerability:** Keywords containing literal dots (e.g., \`nc.openbsd\`) were used in regexes without escaping, allowing them to act as wildcards and potentially match malicious strings. Additionally, dangerous Git remote helpers (e.g., \`ext::\`) were not explicitly blocked.
+**Learning:** Security keywords must be strictly escaped when used in regex construction to prevent accidental wildcard matching. Protocol-level dangerous patterns like Git's \`ext::\` helper must be explicitly denylisted.
+**Prevention:** Always escape literal dots in security keyword lists before converting them to regex patterns. Maintain a list of dangerous protocol patterns in \`DANGEROUS_PATTERNS\`.

--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -5,14 +5,14 @@ set -euo pipefail
 
 # Security Hardening: 2026-06-20 - Prevented keyword merging bypasses.
 # Default categories (can be overridden in .command-verify.conf)
-SAFE_KEYWORDS="${SAFE_KEYWORDS:-build:test:lint:check:status:list:help:version:describe:doc:info:show:get:ls:cat:echo:grep:find:pwd:diff:cd:head:tail:sort:uniq:wc:git:log:pgrep:type:which:df:du:free:top:ps:history}"
-CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl:ssh-keygen:openssl:gpg:mv:cp:ln:link:patch:tar:zip:unzip:gzip:gunzip:bzip2:xz:make:touch:gh:xargs}"
+SAFE_KEYWORDS="${SAFE_KEYWORDS:-build:test:lint:check:status:list:help:version:describe:doc:info:show:get:ls:cat:echo:grep:find:pwd:diff:cd:head:tail:sort:uniq:wc:git:log:pgrep:type:which:df:du:free:top:ps:history:rg:fd:zgrep:lsblk:lscpu}"
+CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl:ssh-keygen:openssl:gpg:mv:cp:ln:link:patch:tar:zip:unzip:gzip:gunzip:bzip2:xz:make:touch:gh:xargs:apt:apt-get:yum:dnf:zypper:brew:pipx}"
 # Destructive and administrative commands (strict boundaries)
-DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:killall:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill:sed:truncate:unlink:tee:parted:fdisk:gdisk:sfdisk:wipe:srm:badblocks:alias:unalias:iptables:nft:ufw:firewall-cmd:crontab:-f:-y}"
+DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:killall:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill:sed:truncate:unlink:tee:parted:fdisk:gdisk:sfdisk:wipe:srm:badblocks:alias:unalias:iptables:nft:ufw:firewall-cmd:crontab:pkexec:mount:umount:chroot:unshare:nsenter:git-remote-ext:poweroff:halt:swapon:swapoff:modprobe:insmod:rmmod:sysctl:strace:gdb:-f:-y}"
 # Language interpreters (broad boundaries to catch versioned ones like python3.11)
-INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:pip3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv:lua:awk}"
+INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:pip3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv:lua:awk:expect}"
 # Networking tools (strict boundaries to avoid false positives like curl.sh)
-NETWORK_KEYWORDS="${NETWORK_KEYWORDS:-curl:wget:nc:netcat:nmap:ssh:scp:sftp:rsync:socat:nslookup:dig:host:nc.openbsd:nc.traditional:telnet:ftp:tftp:ssh-add:ssh-agent:ncat:tcpdump:wireshark:tshark:aria2c:lynx:links:elinks}"
+NETWORK_KEYWORDS="${NETWORK_KEYWORDS:-curl:wget:nc:netcat:nmap:ssh:scp:sftp:rsync:socat:nslookup:dig:host:nc.openbsd:nc.traditional:telnet:ftp:tftp:ssh-add:ssh-agent:ncat:tcpdump:wireshark:tshark:aria2c:lynx:links:elinks:rclone:ssh-copy-id:ngrok:cloudflared:aws:gcloud:az}"
 # Script extensions treated as safe — a keyword followed by one of these is a script, not a bare command
 SAFE_EXTENSIONS=(sh py pl rb js ts mjs bash zsh csh ksh fish)
 _ext_str="${SAFE_EXTENSIONS[*]}"
@@ -22,7 +22,7 @@ unset _ext_str
 # Custom patterns for categories (E3)
 SAFE_PATTERNS=()
 CONDITIONAL_PATTERNS=()
-DANGEROUS_PATTERNS=()
+DANGEROUS_PATTERNS=("ext::")
 
 # Load project-specific configuration if available
 if [[ -f ".command-verify.conf" ]]; then
@@ -91,12 +91,19 @@ categorize_command() {
         fi
     done
 
+    # Escape dots in keywords to ensure exact matches in regex
+    local destructive_keywords_regex="${DESTRUCTIVE_KEYWORDS//./\\.}"
+    local interpreter_keywords_regex="${INTERPRETER_KEYWORDS//./\\.}"
+    local network_keywords_regex="${NETWORK_KEYWORDS//./\\.}"
+    local conditional_keywords_regex="${CONDITIONAL_KEYWORDS//./\\.}"
+    local safe_keywords_regex="${SAFE_KEYWORDS//./\\.}"
+
     # Check destructive keywords with broad boundaries (to catch mkfs.ext4)
     # Allows optional trailing alphanumeric chars, dots, and hyphens immediately after the keyword.
     # Security: Use a hardened suffix pattern to avoid false positives from unrelated words.
     # Optimization: Use a loop to validate EVERY match to prevent bypasses where a safe-looking
     # script name in the same command string causes the whole string to be exempt.
-    local destructive_regex="${boundary}(${DESTRUCTIVE_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
+    local destructive_regex="${boundary}(${destructive_keywords_regex//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
     local temp_destructive="$cmd_lower"
     local full_match suffix
     while [[ "$temp_destructive" =~ $destructive_regex ]]; do
@@ -113,7 +120,7 @@ categorize_command() {
 
     # Check interpreter keywords with broad boundaries (to catch python3.11)
     # Allows optional trailing alphanumeric chars, dots, and hyphens immediately after the keyword.
-    local interpreter_regex="${boundary}(${INTERPRETER_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
+    local interpreter_regex="${boundary}(${interpreter_keywords_regex//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
     local temp_interpreter="$cmd_lower"
     while [[ "$temp_interpreter" =~ $interpreter_regex ]]; do
         full_match="${BASH_REMATCH[0]}"
@@ -127,7 +134,7 @@ categorize_command() {
 
     # Check network keywords with broad boundaries
     # Allows optional trailing alphanumeric chars, dots, and hyphens immediately after the keyword.
-    local network_regex="${boundary}(${NETWORK_KEYWORDS//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
+    local network_regex="${boundary}(${network_keywords_regex//:/|})([.][a-z0-9]+|[0-9-][a-z0-9.]*)?${broad_end_boundary}"
     local temp_network="$cmd_lower"
     while [[ "$temp_network" =~ $network_regex ]]; do
         full_match="${BASH_REMATCH[0]}"
@@ -149,7 +156,7 @@ categorize_command() {
     done
 
     # Check conditional keywords with boundaries
-    local conditional_regex="${boundary}(${CONDITIONAL_KEYWORDS//:/|})${end_boundary}"
+    local conditional_regex="${boundary}(${conditional_keywords_regex//:/|})${end_boundary}"
     if [[ "$cmd_lower" =~ $conditional_regex ]]; then
         printf "conditional\n"
         return 0
@@ -165,7 +172,7 @@ categorize_command() {
     done
 
     # Check safe keywords with boundaries
-    local safe_regex="${boundary}(${SAFE_KEYWORDS//:/|})${end_boundary}"
+    local safe_regex="${boundary}(${safe_keywords_regex//:/|})${end_boundary}"
     if [[ "$cmd_lower" =~ $safe_regex ]]; then
         printf "safe\n"
         return 0

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -58,6 +58,17 @@ FORBIDDEN_PATHS = frozenset({
     ".env.development",
     ".env.test",
     ".env.production",
+    ".bash_history",
+    ".zsh_history",
+    ".python_history",
+    ".node_repl_history",
+    "id_rsa",
+    "id_ed25519",
+    "id_ecdsa",
+    "id_dsa",
+    "known_hosts",
+    "authorized_keys",
+    ".git-credentials",
 })
 
 

--- a/tests/test-security-categorization.bats
+++ b/tests/test-security-categorization.bats
@@ -89,3 +89,34 @@ setup() {
     run categorize_command "bash script.sh"
     [ "$output" = "dangerous" ]
 }
+
+@test "harden-command-categorization: detects new administrative and network keywords" {
+    run categorize_command "pkexec ls"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "mount /dev/sdb1 /mnt"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "rclone copy /local /remote"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "expect script.exp"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "aws s3 ls"
+    [ "$output" = "dangerous" ]
+}
+
+@test "harden-command-categorization: detects dangerous git remote helper" {
+    run categorize_command "git remote add origin ext::ssh user@host"
+    [ "$output" = "dangerous" ]
+}
+
+@test "harden-command-categorization: escapes dots in keywords (ADR-010)" {
+    # nc.openbsd should be dangerous, but ncxopenbsd should be unknown
+    run categorize_command "nc.openbsd"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "ncxopenbsd"
+    [ "$output" = "unknown" ]
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command categorization regexes treated dots as wildcards, potentially allowing malicious commands to match safe patterns. Missing coverage for several administrative/network tools and sensitive files (SSH keys, history).
🎯 Impact: Agents could be tricked into running dangerous commands or accessing highly sensitive user credentials and history.
🔧 Fix:
- Escaped dots in keyword lists for exact regex matching.
- Expanded keyword lists to include `pkexec`, `mount`, `rclone`, `aws`, `expect`, `apt-get`, etc.
- Added `ext::` to dangerous patterns to block dangerous Git remote helpers.
- Expanded `FORBIDDEN_PATHS` in `scripts/lib/paths.py` to include SSH keys, shell history, and git credentials.
✅ Verification:
- Added comprehensive tests in `tests/test-security-categorization.bats`.
- Verified all tests pass with `bats` and `pytest`.
- Verified overall project quality with `./scripts/quality_gate.sh`.

---
*PR created automatically by Jules for task [4592905536553062251](https://jules.google.com/task/4592905536553062251) started by @d-o-hub*