### PR TITLE
fix(security): block unspecified ipv6 address in ssrf protection

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/constants.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/constants.py
@@ -81,6 +81,7 @@ USER_AGENT: str = (
 BLOCKED_NETWORKS: list = [
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("::/128"),
     ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),

--- a/.agents/skills/do-web-doc-resolver/scripts/utils/http.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils/http.py
@@ -122,6 +122,7 @@ def is_safe_url(url: str) -> bool:
             "localhost.localdomain",
             "127.0.0.1",
             "::1",
+            "::",
             "0.0.0.0",
         ):
             return False

--- a/.agents/skills/do-web-doc-resolver/tests/test_ssrf_repro.py
+++ b/.agents/skills/do-web-doc-resolver/tests/test_ssrf_repro.py
@@ -8,7 +8,7 @@ import requests
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from scripts.utils import fetch_llms_txt, fetch_url_content, validate_url
+from scripts.utils import fetch_llms_txt, fetch_url_content, is_safe_url, validate_url
 
 
 class TestSSRFGuards:
@@ -30,3 +30,8 @@ class TestSSRFGuards:
 
         result = fetch_url_content("http://public-site.com/redirect")
         assert result is None
+
+    def test_is_safe_url_blocks_unspecified_ipv6(self):
+        """Verify that [::] is blocked by is_safe_url."""
+        assert not is_safe_url("http://[::]/")
+        assert not is_safe_url("http://[::]:8080/")

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,3 +43,8 @@
 **Vulnerability:** Path validation checks against `FORBIDDEN_PATHS` were case-sensitive, potentially allowing bypasses using alternate casing (e.g., `.GIT`, `.Env`) on case-insensitive filesystems or as a general oversight.
 **Learning:** Security denylists for file and directory names must be enforced case-insensitively to account for cross-platform filesystem behavior and to prevent simple obfuscation bypasses.
 **Prevention:** Always normalize path components (e.g., to lowercase) before comparing them against a denylist of forbidden names. Pre-calculating a lowercase set of forbidden strings improves performance.
+
+## 2026-07-08 - Blocking Unspecified IPv6 Address in SSRF Protection
+**Vulnerability:** The `do-web-doc-resolver` skill's SSRF protection did not explicitly block the unspecified IPv6 address `[::]`, which can be used to access services on the local host on many systems.
+**Learning:** SSRF protection must account for all representations of localhost, including both IPv4 (`0.0.0.0`, `127.0.0.1`) and IPv6 (`::1`, `::`) variants. The unspecified address `::` is often treated as localhost by networking stacks.
+**Prevention:** Explicitly include `::` in hostname blocklists and `::/128` in network blocklists for all SSRF validation logic.


### PR DESCRIPTION
Severity: HIGH
Vulnerability: SSRF bypass using unspecified IPv6 address [::]
Impact: Potential access to internal services on localhost.
Fix: Added ::/128 to BLOCKED_NETWORKS and :: to hostname blocklist in do-web-doc-resolver.
Verification: Verified with reproduction script and confirmed existing SSRF tests pass.

---
*PR created automatically by Jules for task [5333416262679199509](https://jules.google.com/task/5333416262679199509) started by @d-o-hub*