### PR TITLE
fix(security): harden command categorization against environment variable injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -48,3 +48,8 @@
 **Vulnerability:** The `do-web-doc-resolver` skill's SSRF protection did not explicitly block the unspecified IPv6 address `[::]`, which can be used to access services on the local host on many systems.
 **Learning:** SSRF protection must account for all representations of localhost, including both IPv4 (`0.0.0.0`, `127.0.0.1`) and IPv6 (`::1`, `::`) variants. The unspecified address `::` is often treated as localhost by networking stacks.
 **Prevention:** Explicitly include `::` in hostname blocklists and `::/128` in network blocklists for all SSRF validation logic.
+
+## 2026-07-14 - Harden Command Categorization against Env Var Injection
+**Vulnerability:** Command categorization could be bypassed by prefixing dangerous commands with environment variable assignments (e.g., `LD_PRELOAD=./evil.so ls`). The '=' and '+' characters were not being normalized, causing keywords to be merged and missed by the boundary-based regex.
+**Learning:** Environment variable assignments are often used in shell commands and can contain both dangerous variables themselves and act as a bypass mechanism for keyword detection. Normalization must include assignment operators to ensure proper tokenization of commands.
+**Prevention:** Always include '=' and '+' in the list of normalized characters for command string analysis. Maintain a list of dangerous environment variables to flag even when they are used at the start of a command without `env`.

--- a/scripts/lib/command-categories.sh
+++ b/scripts/lib/command-categories.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 SAFE_KEYWORDS="${SAFE_KEYWORDS:-build:test:lint:check:status:list:help:version:describe:doc:info:show:get:ls:cat:echo:grep:find:pwd:diff:cd:head:tail:sort:uniq:wc:git:log:pgrep:type:which:df:du:free:top:ps:history}"
 CONDITIONAL_KEYWORDS="${CONDITIONAL_KEYWORDS:-install:clean:format:migrate:update:init:add:remove:delete:replace:chmod:chown:chgrp:setfacl:ssh-keygen:openssl:gpg:mv:cp:ln:link:patch:tar:zip:unzip:gzip:gunzip:bzip2:xz:make:touch:gh:xargs:apt:apt-get:yum:dnf:zypper:brew:pipx}"
 # Destructive and administrative commands (strict boundaries)
-DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:killall:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill:sed:truncate:unlink:tee:parted:fdisk:gdisk:sfdisk:wipe:srm:badblocks:alias:unalias:iptables:nft:ufw:firewall-cmd:crontab:pkexec:mount:umount:chroot:unshare:nsenter:git-remote-ext:poweroff:halt:swapon:swapoff:modprobe:insmod:rmmod:sysctl:strace:gdb:-f:-y}"
+DESTRUCTIVE_KEYWORDS="${DESTRUCTIVE_KEYWORDS:-rm:delete:drop:force:destroy:purge:reset:hard:kill:killall:terminate:eval:exec:sudo:doas:docker:kubectl:podman:rmdir:dd:source:env:su:systemctl:shred:mkfs:mke2fs:mkswap:cryptsetup:reboot:shutdown:pkill:sed:truncate:unlink:tee:parted:fdisk:gdisk:sfdisk:wipe:srm:badblocks:alias:unalias:iptables:nft:ufw:firewall-cmd:crontab:pkexec:mount:umount:chroot:unshare:nsenter:git-remote-ext:poweroff:halt:swapon:swapoff:modprobe:insmod:rmmod:sysctl:strace:gdb:ld_preload:ld_library_path:pythonpath:node_options:bash_env:ps4:-f:-y}"
 # Language interpreters (broad boundaries to catch versioned ones like python3.11)
 INTERPRETER_KEYWORDS="${INTERPRETER_KEYWORDS:-sh:bash:zsh:python:python3:pip3:node:perl:ruby:php:deno:bun:npx:npm:yarn:pnpm:cargo:go:pip:composer:bundle:pipenv:poetry:conda:mamba:uv:lua:awk}"
 # Networking tools (strict boundaries to avoid false positives like curl.sh)
@@ -62,6 +62,8 @@ categorize_command() {
     cmd_lower="${cmd_lower//</ }"
     cmd_lower="${cmd_lower//>/ }"
     cmd_lower="${cmd_lower//,/ }"
+    cmd_lower="${cmd_lower//=/ }"
+    cmd_lower="${cmd_lower//+/ }"
 
     # Note: Using `cmd_lower="${cmd_lower,,}"` is supported as per repository memory for bash 4.0+.
     cmd_lower="${cmd_lower,,}"

--- a/tests/test-env-var-hardening.bats
+++ b/tests/test-env-var-hardening.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+setup() {
+    export REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    source "$REPO_ROOT/scripts/lib/command-categories.sh"
+}
+
+@test "env-var-hardening: detects LD_PRELOAD injection" {
+    run categorize_command "LD_PRELOAD=./evil.so ls"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: detects PYTHONPATH injection" {
+    run categorize_command "PYTHONPATH=/tmp/evil python3 script.py"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: detects NODE_OPTIONS injection" {
+    run categorize_command "NODE_OPTIONS='--loader ./evil.mjs' node script.js"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: detects BASH_ENV injection" {
+    run categorize_command "BASH_ENV=/tmp/evil.sh bash script.sh"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: detects ENV injection" {
+    run categorize_command "ENV=/tmp/evil.sh sh script.sh"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: detects PS4 injection" {
+    run categorize_command "PS4='\$(whoami) ' bash -x script.sh"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: handles multiple env vars and mixed case" {
+    run categorize_command "LD_PRELOAD=./evil.so PYTHONPATH=/tmp/evil python3"
+    [ "$output" = "dangerous" ]
+
+    run categorize_command "ld_preload=./evil.so ls"
+    [ "$output" = "dangerous" ]
+}
+
+@test "env-var-hardening: handles plus in env vars (e.g. for append)" {
+    # Some systems/shells might support += for env vars in some contexts,
+    # or it might just be part of a malicious string.
+    run categorize_command "PYTHONPATH+=:/tmp/evil python3"
+    [ "$output" = "dangerous" ]
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix environment variable injection bypass

🚨 Severity: HIGH
💡 Vulnerability: Command categorization bypass via environment variable prefixing.
🎯 Impact: Dangerous commands can be executed by prefixing them with environment variables (e.g., LD_PRELOAD=./evil.so ls), which were previously missed because the assignment operator '=' was not normalized.
🔧 Fix: Normalized '=' and '+' characters to spaces in command analysis and added dangerous environment variables to the blocklist.
✅ Verification: New BATS tests verify that various injection patterns are correctly flagged as dangerous.

---
*PR created automatically by Jules for task [13567956921670064071](https://jules.google.com/task/13567956921670064071) started by @d-o-hub*