### PR TITLE
fix(security): harden forbidden paths validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -53,3 +53,9 @@
 **Vulnerability:** Command categorization could be bypassed by prefixing dangerous commands with environment variable assignments (e.g., `LD_PRELOAD=./evil.so ls`). The '=' and '+' characters were not being normalized, causing keywords to be merged and missed by the boundary-based regex.
 **Learning:** Environment variable assignments are often used in shell commands and can contain both dangerous variables themselves and act as a bypass mechanism for keyword detection. Normalization must include assignment operators to ensure proper tokenization of commands.
 **Prevention:** Always include '=' and '+' in the list of normalized characters for command string analysis. Maintain a list of dangerous environment variables to flag even when they are used at the start of a command without `env`.
+
+## 2026-07-15 - Hardening Forbidden Paths with Pattern Blocking
+
+**Vulnerability:** Static denylists for forbidden paths were insufficient to catch variations of sensitive files like custom environment files (e.g., .env.local) or credential files with various names (e.g., cert.pem, key.pfx).
+**Learning:** Security validation must combine explicit denylists with pattern-based matching to provide broader coverage against known sensitive file types and naming conventions.
+**Prevention:** Implement suffix and prefix matching in path validation logic to block entire classes of sensitive files (e.g., *.pem, *.key, .env*) in addition to maintaining a comprehensive list of specific forbidden filenames.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ readonly DEFAULT_TIMEOUT_SECONDS=1800
 # Git/PR configuration
 readonly MAX_COMMIT_SUBJECT_LENGTH=150
 readonly MAX_PR_TITLE_LENGTH=150
+readonly MAX_PR_BODY_LENGTH=1000
 ```
 
 ## Development Phases
@@ -109,7 +110,7 @@ Use the `static-analysis` skill to triage and fix any findings before committing
 - **Validation**: `echo "title" | npx commitlint --config commitlint.config.cjs` (or `gh pr edit`)
 - PR Title: `type(scope): description` (max `${MAX_PR_TITLE_LENGTH}` chars)
 - Commit Header: `type(scope): subject` (max `${MAX_COMMIT_SUBJECT_LENGTH}` chars total, lowercase)
-- Commit Body: no hard limit (body-max-length disabled in commitlint; enforced at PR level as 1000 chars). Wrap at 100 chars per line. Footer: max 1000 chars.
+- Commit Body: Enforced at PR level as `${MAX_PR_BODY_LENGTH}` chars (GitHub concatenates title + body for squash-merge commits). Wrap at 100 chars per line. Footer: max 1000 chars.
 - Branch per feature; One concern per PR; Never commit to `main`.
 
 ### Commit Type Mapping

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -61,6 +61,14 @@ FORBIDDEN_PATHS = frozenset({
     ".zsh_history",
     ".python_history",
     ".node_repl_history",
+    ".sh_history",
+    ".lesshst",
+    ".viminfo",
+    ".mysql_history",
+    ".psql_history",
+    ".sqlite_history",
+    "terraform.tfstate.backup",
+    ".terraform",
     "id_rsa",
     "id_ed25519",
     "id_ecdsa",
@@ -107,9 +115,20 @@ def validate_safe_path(
 
     if check_forbidden and candidate != base_resolved:
         for part in candidate.relative_to(base_resolved).parts:
-            if part.lower() in FORBIDDEN_PATHS_LOWER:
+            part_lower = part.lower()
+            # Strict matches
+            if part_lower in FORBIDDEN_PATHS_LOWER:
                 raise PathValidationError(
                     f"--{param_name} targets a forbidden path: {part}"
+                )
+
+            # Pattern-based matches
+            if (
+                part_lower.startswith(".env") or
+                part_lower.endswith((".pem", ".key", ".pfx", ".tfstate"))
+            ):
+                raise PathValidationError(
+                    f"--{param_name} targets a sensitive file pattern: {part}"
                 )
 
     return candidate

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -68,7 +68,7 @@ FORBIDDEN_PATHS = frozenset({
     ".psql_history",
     ".sqlite_history",
     "terraform.tfstate.backup",
-    ".terraform",
+    ".terraform",  # Directory: blocks .terraform/ and its contents
     "id_rsa",
     "id_ed25519",
     "id_ecdsa",
@@ -123,9 +123,12 @@ def validate_safe_path(
                 )
 
             # Pattern-based matches
+            # .env* covers various environment file naming conventions.
+            # Extensions cover common certificate, private key, and state formats.
+            # Note: .key is intentionally broad to catch private keys despite potential false positives.
             if (
                 part_lower.startswith(".env") or
-                part_lower.endswith((".pem", ".key", ".pfx", ".tfstate"))
+                part_lower.endswith((".pem", ".key", ".pfx", ".tfstate", ".crt", ".cer"))
             ):
                 raise PathValidationError(
                     f"--{param_name} targets a sensitive file pattern: {part}"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -67,6 +67,38 @@ def test_validate_safe_path_forbidden(tmp_path):
     with pytest.raises(PathValidationError):
         validate_safe_path("id_rsa", base, "test", check_forbidden=True)
 
+    # Test newly added shell/app history and terraform paths
+    new_forbidden = [
+        ".sh_history", ".lesshst", ".viminfo", ".mysql_history",
+        ".psql_history", ".sqlite_history", "terraform.tfstate",
+        "terraform.tfstate.backup", ".terraform"
+    ]
+    for p in new_forbidden:
+        with pytest.raises(PathValidationError):
+            validate_safe_path(p, base, "test", check_forbidden=True)
+
+
+def test_validate_safe_path_patterns(tmp_path):
+    base = tmp_path / "repo"
+    base.mkdir()
+
+    # .env* patterns
+    with pytest.raises(PathValidationError):
+        validate_safe_path(".env.custom", base, "test", check_forbidden=True)
+    with pytest.raises(PathValidationError):
+        validate_safe_path(".env.local.backup", base, "test", check_forbidden=True)
+
+    # Sensitive extension patterns
+    sensitive_extensions = ["secret.pem", "my.key", "cert.pfx", "prod.tfstate"]
+    for p in sensitive_extensions:
+        with pytest.raises(PathValidationError):
+            validate_safe_path(p, base, "test", check_forbidden=True)
+
+    # Nested pattern matches
+    (base / "subdir").mkdir()
+    with pytest.raises(PathValidationError):
+        validate_safe_path("subdir/id_rsa.pem", base, "test", check_forbidden=True)
+
 
 def test_validate_safe_path_case_insensitivity(tmp_path):
     base = tmp_path / "repo"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -68,6 +68,7 @@ def test_validate_safe_path_forbidden(tmp_path):
         validate_safe_path("id_rsa", base, "test", check_forbidden=True)
 
     # Test newly added shell/app history and terraform paths
+    # Note: terraform.tfstate is covered by pattern matching, others by explicit denylist
     new_forbidden = [
         ".sh_history", ".lesshst", ".viminfo", ".mysql_history",
         ".psql_history", ".sqlite_history", "terraform.tfstate",
@@ -89,8 +90,17 @@ def test_validate_safe_path_patterns(tmp_path):
         validate_safe_path(".env.local.backup", base, "test", check_forbidden=True)
 
     # Sensitive extension patterns
-    sensitive_extensions = ["secret.pem", "my.key", "cert.pfx", "prod.tfstate"]
+    sensitive_extensions = [
+        "secret.pem", "my.key", "cert.pfx", "prod.tfstate",
+        "cert.crt", "bundle.cer"
+    ]
     for p in sensitive_extensions:
+        with pytest.raises(PathValidationError):
+            validate_safe_path(p, base, "test", check_forbidden=True)
+
+    # Case-insensitivity for patterns
+    case_patterns = [".ENV.LOCAL", "SECRET.PEM", "MY.KEY"]
+    for p in case_patterns:
         with pytest.raises(PathValidationError):
             validate_safe_path(p, base, "test", check_forbidden=True)
 


### PR DESCRIPTION
Hardens path validation against sensitive file variants.

- Expand FORBIDDEN_PATHS (shell/DB history, Terraform)
- Pattern block: .env*, .pem/.key/.pfx/.tfstate/.crt/.cer
- Tests in tests/test_paths.py
- Document MAX_PR_BODY_LENGTH in AGENTS.md

Severity: medium. Agents could reach slightly renamed secrets if only a static denylist is used.
