### PR TITLE
fix(security): harden forbidden paths with pattern SSH blocking and alternate VCS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -59,3 +59,9 @@
 **Vulnerability:** Static denylists for forbidden paths were insufficient to catch variations of sensitive files like custom environment files (e.g., .env.local) or credential files with various names (e.g., cert.pem, key.pfx).
 **Learning:** Security validation must combine explicit denylists with pattern-based matching to provide broader coverage against known sensitive file types and naming conventions.
 **Prevention:** Implement suffix and prefix matching in path validation logic to block entire classes of sensitive files (e.g., *.pem, *.key, .env*) in addition to maintaining a comprehensive list of specific forbidden filenames.
+
+## 2026-07-22 - Pattern-Based SSH Private Key Blocking and Multi-VCS Hardening
+
+**Vulnerability:** Static exact-matching of specific SSH key names (e.g., `id_rsa`, `id_ed25519`) failed to block SSH keys using newer algorithms (e.g., `id_ed25519_sk`, `id_ecdsa_sk`), custom suffixes, or backups (e.g., `id_rsa_backup`, `id_rsa.old`). Additionally, other version control systems like Mercurial (`.hg`) and Subversion (`.svn`) were not explicitly blocked in forbidden path validation.
+**Learning:** Hardcoded lists of exact filenames are prone to omissions. Combining prefix and suffix matching allows blocking an entire class of sensitive keys (such as any file starting with `id_rsa` or similar that does not end with `.pub`) while allowing public keys, ensuring robust coverage for alternative structures and metadata.
+**Prevention:** Apply dynamic prefix-based patterns in combination with exclusion lists (e.g., `not endswith('.pub')`) to block private key variations. Expand static denylists to encompass alternative VCS folders and shell histories to enforce comprehensive coverage.

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -83,6 +83,13 @@ FORBIDDEN_PATHS = frozenset({
     ".inputrc",
     ".wget-hsts",
     "rclone.conf",
+    ".hg",
+    ".hgignore",
+    ".hgrc",
+    ".svn",
+    ".fish_history",
+    ".ash_history",
+    ".tcsh_history",
 })
 
 # Pre-calculate lowercase forbidden paths for efficient case-insensitive matching.
@@ -130,9 +137,14 @@ def validate_safe_path(
             # .env* covers various environment file naming conventions.
             # Extensions cover common certificate, private key, and state formats.
             # Note: .key is intentionally broad to catch private keys despite potential false positives.
+            # SSH private key prefixes cover custom-named keys and newer types (e.g. id_ed25519_sk, id_rsa_backup).
             if (
                 part_lower.startswith(".env") or
-                part_lower.endswith((".pem", ".key", ".pfx", ".tfstate", ".crt", ".cer"))
+                part_lower.endswith((".pem", ".key", ".pfx", ".tfstate", ".crt", ".cer")) or
+                (
+                    part_lower.startswith(("id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "id_xmss")) and
+                    not part_lower.endswith(".pub")
+                )
             ):
                 raise PathValidationError(
                     f"--{param_name} targets a sensitive file pattern: {part}"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -109,6 +109,31 @@ def test_validate_safe_path_patterns(tmp_path):
     with pytest.raises(PathValidationError):
         validate_safe_path("subdir/id_rsa.pem", base, "test", check_forbidden=True)
 
+    # SSH private key pattern-based matches (custom/backup suffixes)
+    ssh_private_patterns = [
+        "id_rsa_backup", "id_ed25519_sk", "id_ecdsa_old", "id_xmss.backup"
+    ]
+    for p in ssh_private_patterns:
+        with pytest.raises(PathValidationError):
+            validate_safe_path(p, base, "test", check_forbidden=True)
+
+    # Public keys should be allowed
+    ssh_public_patterns = [
+        "id_rsa.pub", "id_ed25519_sk.pub", "id_ecdsa_old.pub"
+    ]
+    for p in ssh_public_patterns:
+        res = validate_safe_path(p, base, "test", check_forbidden=True)
+        assert res == (base / p).resolve()
+
+    # Explicit checks for newly added VCS folders and alternative shell histories
+    vcs_and_histories = [
+        ".hg", ".hgignore", ".hgrc", ".svn",
+        ".fish_history", ".ash_history", ".tcsh_history"
+    ]
+    for p in vcs_and_histories:
+        with pytest.raises(PathValidationError):
+            validate_safe_path(p, base, "test", check_forbidden=True)
+
 
 def test_validate_safe_path_case_insensitivity(tmp_path):
     base = tmp_path / "repo"


### PR DESCRIPTION
Harden path validation in scripts/lib/paths.py to explicitly block .hg, .svn, and additional alternative shell histories, and add dynamic pattern-based blocking for SSH private keys of various algorithms/formats (e.g., id_ed25519_sk, id_rsa_backup) while allowing .pub public keys. Add comprehensive unit tests in tests/test_paths.py and append to the security journal in .jules/sentinel.md.

---
*PR created automatically by Jules for task [3827050556803909521](https://jules.google.com/task/3827050556803909521) started by @d-o-hub*