### PR TITLE
perf: eliminate grep process forks in adr compliance check

### DIFF
--- a/scripts/check-adr-compliance.sh
+++ b/scripts/check-adr-compliance.sh
@@ -39,8 +39,10 @@ if [[ ! -f "$STATUS_FILE" ]]; then
     log_fail "plans/_status.json not found but ADR files exist!"
   fi
 else
+  # perf: read file contents once and use native bash matching to eliminate grep process fork overhead in loop
+  STATUS_CONTENT=$(<"$STATUS_FILE")
   for f in "${ADR_FILES[@]}"; do
-    if grep -q -- "\"$f\"" "$STATUS_FILE"; then :
+    if [[ "$STATUS_CONTENT" == *"\"$f\""* ]]; then :
     else log_fail "$f NOT registered in _status.json"; fi
   done
 fi


### PR DESCRIPTION
What: Replaced `grep -q` inside a `for` loop with native bash string matching (`[[ "$STATUS_CONTENT" == *"\"$f\""* ]]`) in `scripts/check-adr-compliance.sh`.
Why: Running `grep -q` inside a loop spawns a new process on every iteration, which is a major performance bottleneck in bash scripts, especially as the number of ADR files grows.
Impact: Eliminates $O(N)$ process fork overhead, reducing execution time significantly.
Measurement: Compare the execution time of `./scripts/check-adr-compliance.sh` before and after this change.

---
*PR created automatically by Jules for task [4554526074788142610](https://jules.google.com/task/4554526074788142610) started by @d-o-hub*