### PR TITLE
fix(security): harden path validation for identity keys and keystores

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -71,3 +71,9 @@
 **Vulnerability:** Static path denylists for specific filenames like `id_rsa` or `id_ed25519` are insufficient to prevent access/exposure of SSH private keys with custom/dynamic names (e.g. `id_rsa_personal`, `id_ed25519_github`).
 **Learning:** Security validation logic must use wildcard or pattern-based prefix matching to capture all variants of SSH private keys, while safely exempting public key counterparts (ending with `.pub`) to avoid breaking valid references.
 **Prevention:** In `validate_safe_path`, block any path component starting with standard SSH key prefixes (`id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`, `id_xmss`) if they do not end with `.pub`.
+
+## 2026-07-23 - Hardened Path Validation for Identity Keys and Keystores
+
+**Vulnerability:** Gaps in pattern-based path blocking permitted exposure or manipulation of critical credential formats, keystores, and standard identity key prefixes (such as `.p12`, `.pkcs8`, `.pk8`, `.der`, `.keystore`, `.jks`, `.dockercfg`, `.publishsettings`, and keys starting with `identity`).
+**Learning:** Path protection lists must explicitly cover all standard, cross-platform private key containers and developer identity prefixes, as these files are frequently targeted for credential exfiltration.
+**Prevention:** Always maintain a comprehensive, pattern-based validation filter in `validate_safe_path` that blocks standard identity patterns and Java/web key storage formats while safely permitting public files (e.g., public keys with `.pub`).

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -140,9 +140,15 @@ def validate_safe_path(
             # SSH private key prefixes cover custom-named keys and newer types (e.g. id_ed25519_sk, id_rsa_backup).
             if (
                 part_lower.startswith(".env") or
-                part_lower.endswith((".pem", ".key", ".pfx", ".tfstate", ".crt", ".cer")) or
+                part_lower.endswith((
+                    ".pem", ".key", ".pfx", ".tfstate", ".crt", ".cer",
+                    ".p12", ".pkcs8", ".pk8", ".der", ".keystore", ".jks",
+                    ".dockercfg", ".publishsettings"
+                )) or
                 (
-                    part_lower.startswith(("id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "id_xmss")) and
+                    part_lower.startswith((
+                        "identity", "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "id_xmss"
+                    )) and
                     not part_lower.endswith(".pub")
                 )
             ):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -92,7 +92,9 @@ def test_validate_safe_path_patterns(tmp_path):
     # Sensitive extension patterns
     sensitive_extensions = [
         "secret.pem", "my.key", "cert.pfx", "prod.tfstate",
-        "cert.crt", "bundle.cer"
+        "cert.crt", "bundle.cer", "key.p12", "id.pkcs8",
+        "private.pk8", "cert.der", "my.keystore", "my.jks",
+        "config.dockercfg", "backup.publishsettings"
     ]
     for p in sensitive_extensions:
         with pytest.raises(PathValidationError):
@@ -168,13 +170,19 @@ def test_validate_safe_path_ssh_keys(tmp_path):
     base.mkdir()
 
     # Dynamic private keys (e.g. custom names)
-    private_keys = ["id_rsa_personal", "id_ed25519_github", "id_dsa_old", "id_ecdsa_corp", "id_xmss_test"]
+    private_keys = [
+        "id_rsa_personal", "id_ed25519_github", "id_dsa_old", "id_ecdsa_corp", "id_xmss_test",
+        "identity", "identity_backup", "identity_sk"
+    ]
     for pk in private_keys:
         with pytest.raises(PathValidationError):
             validate_safe_path(pk, base, "test", check_forbidden=True)
 
     # Public keys should be allowed
-    public_keys = ["id_rsa.pub", "id_ed25519_github.pub", "id_dsa_old.pub", "id_ecdsa_corp.pub", "id_xmss_test.pub"]
+    public_keys = [
+        "id_rsa.pub", "id_ed25519_github.pub", "id_dsa_old.pub", "id_ecdsa_corp.pub", "id_xmss_test.pub",
+        "identity.pub", "identity_backup.pub", "identity_sk.pub"
+    ]
     for pub in public_keys:
         res = validate_safe_path(pub, base, "test", check_forbidden=True)
         expected = (base / pub).resolve()


### PR DESCRIPTION
# 🛡️ Sentinel: Fix potential path traversal or sensitive file exposure

🚨 **Severity**: MEDIUM/HIGH

💡 **Vulnerability**: Path validation pattern-matching checks had gaps, allowing developer tools or agents to read or expose private credential, keystore, certificate, and standard identity format files (such as `.p12`, `.pkcs8`, `.pk8`, `.der`, `.keystore`, `.jks`, `.dockercfg`, `.publishsettings`, and private keys starting with `identity`).

🎯 **Impact**: Potential exposure, theft, or manipulation of private keys, SSL/TLS certificates, cloud credentials, or client authentication stores.

🔧 **Fix**: Expanded pattern-based checks in `scripts/lib/paths.py::validate_safe_path` to reject sensitive file endings and `identity` prefix while safely permitting public keys ending in `.pub`.

✅ **Verification**: Run `PYTHONPATH=scripts/lib pytest tests/test_paths.py` or run `bash scripts/quality_gate.sh`. All checks pass with 100% success.

---
*PR created automatically by Jules for task [6162361607403098509](https://jules.google.com/task/6162361607403098509) started by @d-o-hub*