### PR TITLE
fix(do-wdr): improve error handling and type safety

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/providers/jina.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/providers/jina.py
@@ -53,7 +53,7 @@ async def resolve_with_jina_async(url: str, max_chars: int = MAX_CHARS) -> Resol
         result = ResolvedResult(source="jina", content=content[:max_chars], url=url)
         _save_to_cache(url, "jina", result.to_dict())
         return result
-    except httpx.RequestError as e:
+    except (httpx.RequestError, OSError, TimeoutError) as e:
         logger.warning("Jina resolution failed: %s: %s", type(e).__name__, e)
         return None
 
@@ -96,6 +96,6 @@ def resolve_with_jina(url: str, max_chars: int = MAX_CHARS) -> ResolvedResult | 
         result = ResolvedResult(source="jina", content=content[:max_chars], url=url)
         _save_to_cache(url, "jina", result.to_dict())
         return result
-    except httpx.RequestError as e:
+    except (httpx.RequestError, OSError, TimeoutError) as e:
         logger.warning("Jina resolution failed: %s: %s", type(e).__name__, e)
         return None

--- a/.agents/skills/do-web-doc-resolver/scripts/providers/serper.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/providers/serper.py
@@ -73,7 +73,7 @@ async def resolve_with_serper_async(
         result = ResolvedResult(source="serper", content=content[:max_chars], query=query)
         _save_to_cache(query, "serper", result.to_dict())
         return result
-    except httpx.RequestError as e:
+    except (httpx.RequestError, OSError, TimeoutError) as e:
         logger.warning("Serper resolution failed: %s: %s", type(e).__name__, e)
         return None
 
@@ -134,6 +134,6 @@ def resolve_with_serper(query: str, max_chars: int = MAX_CHARS) -> ResolvedResul
         result = ResolvedResult(source="serper", content=content[:max_chars], query=query)
         _save_to_cache(query, "serper", result.to_dict())
         return result
-    except httpx.RequestError as e:
+    except (httpx.RequestError, OSError, TimeoutError) as e:
         logger.warning("Serper resolution failed: %s: %s", type(e).__name__, e)
         return None

--- a/.agents/skills/do-web-doc-resolver/scripts/routing_memory.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/routing_memory.py
@@ -7,6 +7,7 @@ import math
 import threading
 import time
 from collections import defaultdict
+from typing import Any, cast
 
 from scripts._routing_utils import DEFAULT_PROVIDER_STATS, compute_p75_latency
 
@@ -17,9 +18,11 @@ SCORE_SCALE = 1000.0
 
 
 class RoutingMemory:
-    def __init__(self):
+    def __init__(self) -> None:
         # domain -> provider -> stats
-        self.domain_stats = defaultdict(lambda: defaultdict(lambda: dict(DEFAULT_PROVIDER_STATS)))
+        self.domain_stats: dict[str, dict[str, dict[str, Any]]] = defaultdict(
+            lambda: defaultdict(lambda: dict(DEFAULT_PROVIDER_STATS))
+        )
         self._lock = threading.RLock()
 
     def record(
@@ -27,35 +30,46 @@ class RoutingMemory:
     ) -> None:
         with self._lock:
             stats = self.domain_stats[domain][provider]
-            total = stats["success"] + stats["failure"]
-            stats["avg_latency_ms"] = ((stats["avg_latency_ms"] * total) + latency_ms) / (total + 1)
-            stats["avg_quality"] = ((stats["avg_quality"] * total) + quality_score) / (total + 1)
+            s = cast(int, stats.get("success", 0))
+            f = cast(int, stats.get("failure", 0))
+            total = s + f
+
+            avg_lat = cast(float, stats.get("avg_latency_ms", 0.0))
+            avg_qual = cast(float, stats.get("avg_quality", 0.0))
+
+            stats["avg_latency_ms"] = ((avg_lat * total) + float(latency_ms)) / (total + 1)
+            stats["avg_quality"] = ((avg_qual * total) + float(quality_score)) / (total + 1)
             stats["last_attempted"] = time.time()
             if success:
-                stats["success"] += 1
+                stats["success"] = s + 1
             else:
-                stats["failure"] += 1
+                stats["failure"] = f + 1
 
-    def get_domain_stats(self, provider: str, domain: str) -> dict | None:
+    def get_domain_stats(self, provider: str, domain: str) -> dict[str, Any] | None:
         with self._lock:
-            if domain not in self.domain_stats or provider not in self.domain_stats[domain]:
+            domain_dict = self.domain_stats.get(domain)
+            if not domain_dict:
+                return None
+            stats = domain_dict.get(provider)
+            if not stats:
                 return None
 
-            stats = self.domain_stats[domain][provider]
-            attempts = stats.get("success", 0) + stats.get("failure", 0)
+            s = cast(int, stats.get("success", 0))
+            f = cast(int, stats.get("failure", 0))
+            attempts = s + f
             if attempts == 0:
                 return None
 
-            success_rate = stats.get("success", 0) / max(attempts, 1)
+            success_rate = float(s) / max(attempts, 1)
             days_since_last = 0.0
-            last = stats.get("last_attempted")
+            last = cast(float | None, stats.get("last_attempted"))
             if last:
                 days_since_last = (time.time() - last) / 86400.0
 
             return {
                 "attempts": attempts,
                 "success_rate": success_rate,
-                "avg_latency_ms": stats.get("avg_latency_ms", 0),
+                "avg_latency_ms": stats.get("avg_latency_ms", 0.0),
                 "avg_quality": stats.get("avg_quality", 0.5),
                 "days_since_last": days_since_last,
             }
@@ -97,10 +111,13 @@ class RoutingMemory:
 
     def get_p75_latency(self, domain: str, provider: str, default: int = 3000) -> int:
         with self._lock:
-            stats = self.domain_stats.get(domain, {}).get(provider)
+            domain_dict = self.domain_stats.get(domain)
+            if not domain_dict:
+                return default
+            stats = domain_dict.get(provider)
             if not stats:
                 return default
-            return compute_p75_latency(stats["avg_latency_ms"], default)
+            return compute_p75_latency(cast(float, stats["avg_latency_ms"]), default)
 
     def clear(self) -> None:
         with self._lock:


### PR DESCRIPTION
## Summary
- Broaden exception catching in jina.py and serper.py to handle OSError and TimeoutError alongside httpx.RequestError
- Add type annotations and cast() calls to routing_memory.py for better type safety

## Changes
- `scripts/providers/jina.py`: Catch `(httpx.RequestError, OSError, TimeoutError)` instead of just `httpx.RequestError`
- `scripts/providers/serper.py`: Same broadened exception handling
- `scripts/routing_memory.py`: Add `typing.Any`, `cast`, typed dict annotations for `domain_stats`, return types

## Testing
- All existing tests pass
- Quality gate passed
- No new dependencies

Part of the split from #719.