### PR TITLE
fix(do-wdr): deduplicate _l1_clear helper after squash-merge collision

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/utils/__init__.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils/__init__.py
@@ -22,7 +22,6 @@ from scripts.utils.cache import (
     _l1_clear,
     get_cache,
     get_ttl,
-    _l1_clear,
 )
 from scripts.utils.content_clean import clean_content
 from scripts.utils.fetch import (
@@ -165,7 +164,6 @@ __all__ = [
     "_l1_clear",
     "get_cache",
     "get_ttl",
-    "_l1_clear",
     # URL utilities
     "is_url",
     "normalize_url",

--- a/.agents/skills/do-web-doc-resolver/scripts/utils/cache.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils/cache.py
@@ -58,15 +58,15 @@ def _get_cache():
 
 
 def _l1_clear():
-    """Clear the local process cache. Useful for tests."""
+    """Reset _cache to None; lazy re-init on next access (test only).
+
+    Set _cache = None rather than calling _cache.clear() so on-disk cached
+    entries are preserved across test runs while still forcing fresh
+    initialization on the next _get_cache() call.
+    """
     global _cache
     with _cache_lock:
-        if _cache is not None:
-            try:
-                _cache.clear()
-            except Exception as e:
-                logger.debug("Failed to clear local cache: %s", e)
-            _cache = None
+        _cache = None
 
 
 def get_ttl(provider: str, config: dict | None = None) -> int:
@@ -129,10 +129,3 @@ def _save_to_cache(input_str: str, source: str, result: dict[str, Any], ttl: int
 
     with _cache_lock:
         cache.set(_cache_key(input_str, source), result, expire=ttl)
-
-
-def _l1_clear():
-    """Reset the local cache state (clear level 1 cache)."""
-    global _cache
-    with _cache_lock:
-        _cache = None

--- a/.agents/skills/do-web-doc-resolver/tests/test_cache_helpers.py
+++ b/.agents/skills/do-web-doc-resolver/tests/test_cache_helpers.py
@@ -1,0 +1,97 @@
+"""Regression tests for cache/utils helper definitions.
+
+Defends against duplicate helper definitions introduced when multiple PRs from
+the same author/session are squash-merged and both add the same helper. See
+PR cleanup run 2026-07-28 / issue #740.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+
+@pytest.mark.unit
+class TestNoDuplicateHelpers:
+    """Ensure cache helpers are defined exactly once after merges."""
+
+    def test_l1_clear_defined_once(self):
+        """Issue #740: two _l1_clear definitions coexisted on main.
+
+        Uses AST (not inspect.getsource) to be robust against false positives
+        from comments, docstrings, or string literals containing the substring
+        ``def _l1_clear(``.
+        """
+        from scripts.utils import cache
+
+        src = pathlib.Path(cache.__file__).read_text()
+        tree = ast.parse(src)
+        module_level_defs = [
+            n.name
+            for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name == "_l1_clear"
+        ]
+        assert len(module_level_defs) == 1, (
+            "Duplicate _l1_clear helper detected in scripts/utils/cache.py. "
+            "This regression appeared when two PRs from the same session "
+            "added the helper and both squash-merged; see plans/GOAP_STATE.md "
+            "(run 2026-07-28)."
+        )
+
+    def test_l1_clear_export_once_in_utils_all(self):
+        """Issue #740: duplicates in scripts/utils/__init__.py __all__."""
+        from scripts.utils import __all__ as utils_all
+
+        assert utils_all.count("_l1_clear") == 1, (
+            "Duplicate '_l1_clear' string in scripts.utils.__all__."
+        )
+
+
+@pytest.mark.unit
+class TestL1ClearBehavior:
+    """Verify the kept _l1_clear semantics (no .clear(), lock held)."""
+
+    def test_l1_clear_resets_to_none(self):
+        """The kept variant sets _cache = None (not calls .clear())."""
+        from scripts.utils import cache
+
+        original = cache._cache
+        try:
+            cache._cache = object()  # sentinel non-None
+            cache._l1_clear()
+            assert cache._cache is None, "_l1_clear must reset _cache to None"
+        finally:
+            cache._cache = original
+
+    def test_l1_clear_traverses_cache_lock_global(self):
+        """Verify _l1_clear references _cache_lock (no plain assignment path).
+
+        Mocks ``_cache_lock`` with a sentinel context manager. The sentinel's
+        ``__enter__`` records the call. If a future refactor drops the
+        ``with _cache_lock:`` guard, this test fails.
+        """
+        from scripts.utils import cache
+
+        entered = []
+
+        class _SentinelLock:
+            def __enter__(inner):
+                entered.append(True)
+                return inner
+
+            def __exit__(inner, *exc):
+                return False
+
+        original_lock = cache._cache_lock
+        original_cache = cache._cache
+        try:
+            cache._cache_lock = _SentinelLock()
+            cache._cache = object()
+            cache._l1_clear()
+            assert entered == [True], (
+                "_l1_clear must enter _cache_lock as a context manager"
+            )
+            assert cache._cache is None
+        finally:
+            cache._cache_lock = original_lock
+            cache._cache = original_cache


### PR DESCRIPTION
## Problem

Squash-merging both #731 and #733 in the 2026-07-28 PR cleanup batch caused two copies of `_l1_clear` to land on `main`:

- `cache.py`: two top-level `def _l1_clear():` definitions (one defensive with try/except + logger.debug, one simple `_cache = None`).
- `scripts/utils/__init__.py`: duplicate `_l1_clear` entries in the `from scripts.utils.cache import (...)` block and in `__all__`.

Python's late-binding makes the second definition win, silently dropping the defensive try/except behaviour from #731.

## Fix

Keep the simpler variant (`with _cache_lock: _cache = None`) because:

- `_cache.clear()` would delete on-disk cached entries in tests — destructive side-effect we explicitly do not want.
- `_cache = None` forces lazy re-initialization on the next `_get_cache()` call while preserving disk-backed entries.
- Tests SHOULD fail loudly when assumptions break; the defensive variant's silent try/except would mask real bugs in cache setup.

## Regression tests

Added `tests/test_cache_helpers.py` with:

- `test_l1_clear_defined_once` — AST-based detection (robust against false positives from comments/docstrings).
- `test_l1_clear_export_once_in_utils_all` — `__all__` membership test.
- `test_l1_clear_resets_to_none` — behavioral assertion matching the kept variant.
- `test_l1_clear_traverses_cache_lock_global` — sentinel lock verifies the `with _cache_lock:` guard cannot silently drop in future refactors.

## Files

- `.agents/skills/do-web-doc-resolver/scripts/utils/cache.py` (kept simpler variant, dropped duplicate)
- `.agents/skills/do-web-doc-resolver/scripts/utils/__init__.py` (dedup)
- `.agents/skills/do-web-doc-resolver/tests/test_cache_helpers.py` (NEW)

Fixes #740