### PR TITLE
fix(workflows): grant contents: write to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-non-deps.yml
+++ b/.github/workflows/auto-merge-non-deps.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
     steps:
       - name: Enable auto-merge for labeled PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0

--- a/plans/adr-010-automated-pr-auto-merge.md
+++ b/plans/adr-010-automated-pr-auto-merge.md
@@ -120,6 +120,15 @@ opt-in: a maintainer (or designated collaborator) must deliberately add
 the label, and removing the label is a future improvement (currently
 auto-merge once enabled cannot be auto-disabled by this workflow).
 
+**Permissions**: the workflow grants both `pull-requests: write` AND
+`contents: write` on the `GITHUB_TOKEN`, mirroring
+`dependabot-auto-merge.yml`. Empirically (4 consecutive `failure` runs
+on PR #744 with only `pull-requests: write`), the
+`enablePullRequestAutoMerge` GraphQL mutation requires both. The exact
+permission-check behaviour at the API layer is internal to GitHub and
+not formally documented; the safe pattern is to mirror the proven
+dependabot workflow.
+
 **Defense-in-depth**: the workflow re-asserts `isDraft == false` inside the
 GraphQL step so a PR that becomes a draft after the label was applied
 still refuses to auto-merge.


### PR DESCRIPTION
## Problem

`auto-merge-non-deps.yml` has been failing with `failure` conclusion on every PR that carried the `automerge` label (4 consecutive runs on PR #744). Log retrieval via `gh run view --log` and the run-logs API endpoint both returned 404 (logs purged), so the diagnosis is based on static analysis and cross-comparison with the proven `dependabot-auto-merge.yml` workflow.

## Hypothesis

`enablePullRequestAutoMerge` GraphQL mutation empirically requires BOTH `pull-requests: write` AND `contents: write` permissions on the `GITHUB_TOKEN`. The mirror workflow `dependabot-auto-merge.yml` has both and works; `auto-merge-non-deps.yml` only had `pull-requests: write` and failed.

## Fix

Add `contents: write` to the permissions block in `auto-merge-non-deps.yml` to match the proven dependabot workflow.

Also updates `plans/adr-010-automated-pr-auto-merge.md` addendum to document the empirical permission requirement so a future cleanup pass does not regress this configuration.

## Validation

After merge, re-apply the `automerge` label to PR #744 — the workflow should now successfully call `enablePullRequestAutoMerge` and merge PR #744 via squash once CI is green.

## Files changed

- `.github/workflows/auto-merge-non-deps.yml` (+1 line)
- `plans/adr-010-automated-pr-auto-merge.md` (+9 lines)