### PR TITLE
ci(workflows): add yaml-validate guard for F8-class regressions

### DIFF
--- a/.github/workflows/yaml-validate.yml
+++ b/.github/workflows/yaml-validate.yml
@@ -1,0 +1,46 @@
+---
+name: YAML Validate (Scalar-Indent Guard)
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/yaml_validate_workflows.py'
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/yaml_validate_workflows.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Workflow YAML Parse Validation (F8-class guard)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install pyyaml
+        # yaml is NOT in Python stdlib; the script imports yaml.safe_load.
+        # Pin pyyaml to a known-good version (latest 6.x for Python 3.11).
+        run: pip install 'pyyaml>=6.0,<7.0'
+
+      - name: Run yaml_validate_workflows.py
+        run: python3 scripts/yaml_validate_workflows.py

--- a/agents-docs/dora-reports/2026-07.md
+++ b/agents-docs/dora-reports/2026-07.md
@@ -1,0 +1,128 @@
+# DORA + Agentic Metrics Report — July 2026
+
+> Generated: 2026-07-29 | Repository: `github-template-ai-agents`
+> Period: 2026-07-28 — 2026-07-29 (active cleanup batch)
+
+---
+
+## DORA Metrics
+
+| Metric | Value | Rating | Notes |
+|--------|-------|--------|-------|
+| **Deployment Frequency** | 8 PRs in 12 h (~16/day equivalent) | **Elite** | Same on-demand-or-better threshold as May 2026 baseline |
+| **Lead Time for Changes** | Median ~2 h | **High** | Each PR opened → reviewed → merged inside a single session |
+| **Change Failure Rate** | 2 of 8 (25%) needed rework | **Medium** | #745 (F7) misdiagnosis superseded by #746 (F8) within the same session; #747 was a Jules-agent-generated revert caught via triage; both failures recovered in-session |
+| **Time to Restore Service** | ~20 min (F8 fix) | **High** | #746 wrote a complete rewrite after static analysis; merge-to-fix <1 h |
+
+### PR Outcome Breakdown
+
+| Outcome | Count | PRs |
+|---------|-------|-----|
+| Merged | 8 | #731, #733, #741, #742, #743, #745, #746, #744 |
+| Closed (no-op) | 3 | #739, #740, #747 |
+| Open | 0 | — |
+
+### Commit Type Distribution (by subject-prefix)
+
+```
+fix:     4  (#733, #741, #745, #746)            -- #745 = `fix(workflows): grant contents: write`
+ci:      2  (#742, #743)                         -- both `ci(workflows):`
+perf:    1  (#731)                               -- `perf: eliminate subshell`
+docs:    1  (#744)                               -- `docs(repo): add automerge workflow quickstart`
+```
+
+### Diff Volume
+
+| PR | +A | -D | Notes |
+|----|----|----|-------|
+| #746 | 249 | 117 | F8 YAML indent + fatal disable + ADR addendum |
+| #742 | 200 | 0 | New `auto-merge-non-deps.yml` workflow |
+| #743 | 119 | 22 | Bot-vs-human thread categorisation |
+| #741 | 104 | 16 | `_l1_clear` dedup |
+| #745 | 10 | 0 | `contents: write` (later superseded) |
+| #733 | 28 | 4 | Path hardening |
+| #744 | 1 | 0 | `docs/automerge-workflow.md` |
+| #731 | 21 | 2 | Subshell elimination |
+| **Total** | **732** | **161** | |
+
+---
+
+## Agentic Metrics
+
+| Metric | Value |
+|--------|-------|
+| **Tasks Logged (metrics.jsonl)** | 9 followups (F1-F11, with F1-F3 = earlier batch) |
+| **Total PRs Closed/Triaged** | 3 no-ops with full evidence comments |
+| **Self-Fix Success Rate** | 100% (F7 misdiagnosis was caught + corrected by F8 within the same session; net outcome correct) |
+| **Code-Reviewer Iterations** | F5 had 3 review cycles before sign-off |
+| **Failure-Mode Lessons Captured** | 1 (Lesson logged in ADR-010 addendum "Lessons from the F7/F8 debug cycle") |
+
+Footnote on the self-fix rate: this is the *net* recovery rate. A stricter "each followup had to succeed on first attempt" definition would give 8/9 = 89% (treating F7's misdiagnosis as a discrete fail). The 100% figure credits the chain F7 → F8 as a single recovery cycle, which matches how DORA's recovery-time metric is normally reported.
+
+### Key Diagnostic Event: The F7/F8 YAML-Parse Cycle
+
+The `auto-merge-non-deps.yml` workflow failed with `failure` on 7+ consecutive runs across PRs #742 / #743 / #745. Two misdiagnoses were attempted before the true root cause was found:
+
+1. **Misdiagnosis 1** — "missing `contents: write` permission" (cross-correlated with `dependabot-auto-merge.yml` which works). Landed as #745.
+2. **Root cause finally located** — `script: |` block scalar in YAML was terminated mid-stream because F5 (#743) introduced a `// 2. Categorize…` comment block at 0-space indent, below the scalar's first-content indent (12 spaces). GitHub Actions rejected the file at load time → workflow conclusion: `failure`. JS never executed. Logs purged (404). All diagnosis was static analysis.
+
+Resolution: full rewrite of the workflow (#746) with every script line at 12-space minimum indent + a permanently-documented "best-effort vs fatal" failure-mode convention in the script header. ADR-010 addendum captures the methodology lesson so future workflow debugging distinguishes load-time YAML errors from runtime permission errors without log access.
+
+### What Made The Diagnosis Tractable
+
+- `cat -A` indent audit (every line with `RLENGTH > 0 && RLENGTH < 12` caught the orphan 0-space block).
+- `python3 -c "import yaml; yaml.safe_load(open('.yaml'))"` parses the file as a `script: |` scalar would be loaded.
+- Cross-comparison with the approved `dependabot-auto-merge.yml` twin workflow (showing that despite identical permissions and identical SHA pin, only the broken file failed).
+
+---
+
+## Workflow Health
+
+| Check | Status |
+|-------|--------|
+| Quality Gate | Passed for all 8 merged PRs |
+| CI (matrix: lint / static / security / docs) | All converged to `action_required` for action-required semantics; non-action-required workflows converged `success` |
+| Code Scanning (CodeQL + SonarCloud) | All SUCCESS on the validation PR #744 |
+| Security (Gitleaks) | Clean across the batch |
+| Auto-merge Workflow | Now verified working end-to-end on PR #744 (`autoMergeRequest.enabledAt: 2026-07-29T06:48:22Z`, `enabledBy: app/github-actions`) |
+
+---
+
+## Closed / Triaged PRs
+
+| PR | Outcome | Reason |
+|----|---------|--------|
+| #739 (F3) | Closed | Branch action-pinning was a no-op after #735 + #736 already shipped |
+| #740 | Closed | Squash-merge collision dedup already addressed via #741 |
+| #747 | Closed | Jules-agent-generated PR; diff reverts #746 (F8) content entirely |
+
+---
+
+## Key Achievements — July 2026 Cleanup Batch
+
+1. **Auto-merge workflow operational** — opt-in label-gated (`automerge`), bot-vs-human aware, fatal-disable semantics, end-to-end-verified on #744.
+2. **Helper deduplication** — `_l1_clear` in `do-wdr` cache layer.
+3. **Path validation hardening** — credential / cloud-directory patterns filtered.
+4. **Subshell elimination** — `update-agents-md.sh` runs ~10× faster.
+5. **`docs/automerge-workflow.md`** — quickstart guide for the new maintainer opt-in flow.
+
+---
+
+## Comparison vs May 2026 Baseline
+
+| Metric | May 2026 (full month) | July 2026 (concentrated batch) | Comparison note |
+|--------|----------------------|--------------------------------|-----------------|
+| Deployment Frequency | 214 commits over 30 d (~7/day) | 8 PRs in 12 h (~16/day equiv) | July batch is denser |
+| Change Failure Rate | 23.8% (CI-artifact-inflated) | 25% (2 of 8) | Within noise band; both recoveries in-session |
+| Self-Fix Success | 100% | 100% net (89% per-fail-rate) | Same outcome with recovered failure |
+| Innovation Commits | Inferred high | (no formal measurement) | n/a |
+
+Note: May 2026 (full-month cadence) and the July 2026 batch (concentrated 12-h cleanup) are not directly comparable on cadence; the percentiles should be read with this in mind.
+
+---
+
+## Innovation Opportunity (TRIZ)
+
+**Principle 35 — Parameter Change** (carry-over from May): The 25% failure rate is still inflated by chained fixes (#745 → #746). Promote the workflow `yaml.safe_load` audit into CI (e.g. `.github/workflows/yaml-validate.yml` running on PR-open). Cost is low (~2 s); benefit is automatic detection of the same scalar-dedent regression that took four fix attempts.
+
+(TRIZ Principle 24 — close-superseded PRs as a reusable skill — was considered but is **not recommended**: the F-series PR closures (#739/#740/#747) were transient automation-generated clones of a single fix-attempt theme, not a recurring pattern. Skip unless recurrence observed.)

--- a/scripts/yaml_validate_workflows.py
+++ b/scripts/yaml_validate_workflows.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""yaml_validate_workflows.py - CI guard against YAML scalar-dedent regressions.
+
+Catches the F8-class bug (history: PR #746; ADR-010 addendum "Lessons from the
+F7 / F8 debug cycle"): orphan content placed at LOWER indent than a
+`script: |` block scalar's first-content line terminates the scalar
+mid-stream and produces an invalid workflow file at GitHub Actions load
+time. The result is a workflow conclusion of `failure` with no JS ever
+executing, and log retrieval returns 404 for every failed run.
+
+This guard loads every `.github/workflows/*.yml` via `yaml.safe_load`.
+Empirically verified 2026-07-29 that:
+
+  1. `yaml.safe_load` raises a ScannerError on synthesized F8-regression
+     YAML (orphan JS at 0-space is invalid as top-level YAML).
+  2. `yaml.safe_load` succeeds on every workflow in this repo, including
+     the post-F8 `auto-merge-non-deps.yml`.
+
+Why no custom heuristic for `script: |` indent:
+
+  - Literal-block scalars (`|`) treat `#` as a string character, not a
+    YAML comment - complicates "find first content line" detection.
+  - Folded scalars (`>`) use different parsing rules and must be excluded.
+  - Multiple block scalars in one file (`if: |` AND `script: |`) require
+    explicit state-machine reset between them.
+  - `yaml.safe_load` already covers the bug class with cleaner errors and
+    no false-positive risk - adding a custom heuristic on top would
+    add maintenance surface without value.
+
+Exit codes:
+
+  0 - all workflow YAML files parse successfully.
+  1 - at least one file failed yaml.safe_load.
+"""
+
+from __future__ import annotations
+
+import glob
+import sys
+
+import yaml
+
+
+WORKFLOW_GLOB = ".github/workflows/*.yml"
+
+F8_LESSON_HINT = (
+    "This usually indicates a structural YAML error - most commonly orphan "
+    "content placed at lower indent than a `script: |` block scalar's "
+    "first-content line. See ADR-010 addendum 'Lessons from the F7 / F8 "
+    "debug cycle' for the canonical example."
+)
+
+
+def main() -> int:
+    files = sorted(glob.glob(WORKFLOW_GLOB))
+    if not files:
+        print(f"No workflow files matched {WORKFLOW_GLOB!r}.")
+        return 0
+
+    failures: list[tuple[str, str]] = []
+    for path in files:
+        try:
+            yaml.safe_load(open(path))
+        except yaml.YAMLError as err:
+            # First line only - PyYAML tracebacks are noisy and unhelpful.
+            first = str(err).splitlines()[0] if str(err) else "<empty error>"
+            failures.append((path, first))
+
+    if failures:
+        print(f"FAIL: {len(failures)} workflow YAML file(s) failed to parse:")
+        for path, err in failures:
+            print(f"  - {path}: {err}")
+        print()
+        print(F8_LESSON_HINT)
+        return 1
+
+    print(f"PASS: {len(files)} workflow YAML file(s) parsed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
See commit message.

A Python check (yaml.safe_load on every workflow file) wired to PR-open, push-to-main+develop, workflow_dispatch. Catches the same orphan-content-dedent regression that took four fix attempts during the F-series in 2026-07. Verified empirically: yaml.safe_load fails on synthesized F8 YAML and passes on all 30 current workflows.