### PR TITLE
ci(CODEOWNERS): gate workflows + ADR + auto-merge docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS - per-path review gating for CI/ADR-sensitive paths.
+# Background - Jules-task-agent PRs have twice (PRs #747 #748)
+# bundled a legitimate-looking change inside a PR that also
+# reverted these specific file classes. The yaml-validate guard
+# merged via #749 catches structural YAML regressions AFTER merge
+# via yaml.safe_load failure. CODEOWNERS blocks regressions BEFORE
+# merge by routing them to @d-o-hub for review.
+#
+# Patterns use root-relative (leading /) syntax.
+
+# Gate all workflow files (critical for CI infrastructure integrity).
+/.github/workflows/                    @d-o-hub
+/.github/workflows/**                  @d-o-hub
+
+# Gate all architecture decision records.
+/plans/adr-*.md                        @d-o-hub
+
+# Gate the auto-merge workflow documentation (the F4 validation deliverable).
+/docs/automerge-workflow.md            @d-o-hub


### PR DESCRIPTION
Adds .github/CODEOWNERS that requires @d-o-hub review on PRs touching .github/workflows/, plans/adr-*.md, or docs/automerge-workflow.md.

## Background

Jules-task-agent PRs have twice (#747, #748) bundled a legitimate change inside a PR that also reverted these specific file classes. The yaml-validate guard (PR #749) catches structural YAML regressions AFTER merge; this CODEOWNERS gate blocks regressions of these file classes BEFORE merge.

## What it gates

```
/.github/workflows/                    @d-o-hub
/.github/workflows/**                  @d-o-hub
/plans/adr-*.md                        @d-o-hub
/docs/automerge-workflow.md            @d-o-hub
```

External contributors touching non-CI files unaffected. The maintainer overrides by approving directly after review.