### PR TITLE
ci(CODEOWNERS): refine patterns + add /jules/ gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,26 @@
-# CODEOWNERS - per-path review gating for CI/ADR-sensitive paths.
-# Background - Jules-task-agent PRs have twice (PRs #747 #748)
-# bundled a legitimate-looking change inside a PR that also
-# reverted these specific file classes. The yaml-validate guard
-# merged via #749 catches structural YAML regressions AFTER merge
-# via yaml.safe_load failure. CODEOWNERS blocks regressions BEFORE
-# merge by routing them to @d-o-hub for review.
+# CODEOWNERS for d-o-hub/github-template-ai-agents
+# See plans/GOAP_STATE.md and the F-series debug cycle:
+# Jules-task-agent PRs #747 and #748 bundled legitimate-looking
+# changes inside PRs that also reverted workflow + ADR + docs
+# content. The yaml-validate guard (PR #749) catches structural
+# regressions AFTER merge; this file gates human review for
+# the affected content classes BEFORE merge.
 #
-# Patterns use root-relative (leading /) syntax.
+# Note: branch protection currently returns 404 (no required
+# reviews). Soft enforcement today; promote by adding
+# `Require review from Code Owners` to branch protection when ready.
 
-# Gate all workflow files (critical for CI infrastructure integrity).
-/.github/workflows/                    @d-o-hub
-/.github/workflows/**                  @d-o-hub
+# Workflow files - any change to CI machinery
+/.github/workflows/*.yml          @d-o-hub
+/.github/workflows/*.yaml         @d-o-hub
 
-# Gate all architecture decision records.
-/plans/adr-*.md                        @d-o-hub
+# ADR documents that codify workflow design decisions
+/plans/adr-*.md                  @d-o-hub
 
-# Gate the auto-merge workflow documentation (the F4 validation deliverable).
-/docs/automerge-workflow.md            @d-o-hub
+# User-facing docs about the auto-merge workflow
+/docs/automerge-workflow.md      @d-o-hub
+
+# Jules-task-agent artifacts (sentinel.md, bolt.md). Blocking
+# the entire Jules-PR class since they bundle regressions of
+# the above paths in #747 and #748.
+/.jules/                          @d-o-hub

--- a/agents-docs/dora-reports/2026-07.md
+++ b/agents-docs/dora-reports/2026-07.md
@@ -126,3 +126,31 @@ Note: May 2026 (full-month cadence) and the July 2026 batch (concentrated 12-h c
 **Principle 35 — Parameter Change** (carry-over from May): The 25% failure rate is still inflated by chained fixes (#745 → #746). Promote the workflow `yaml.safe_load` audit into CI (e.g. `.github/workflows/yaml-validate.yml` running on PR-open). Cost is low (~2 s); benefit is automatic detection of the same scalar-dedent regression that took four fix attempts.
 
 (TRIZ Principle 24 — close-superseded PRs as a reusable skill — was considered but is **not recommended**: the F-series PR closures (#739/#740/#747) were transient automation-generated clones of a single fix-attempt theme, not a recurring pattern. Skip unless recurrence observed.)
+
+---
+
+# Followup Batch (2026-07-29 07:21Z onwards)
+
+## Summary
+
+| Action | Count | PRs |
+|--------|-------|-----|
+| Merged | 3 | #750, #751, #752 |
+| Total merged this session | 11 | (combined with F-series PRs #731-#749) |
+
+## F14 (PR #750): perf(analyze-codebase) cherry-pick
+
+Branch `perf/cherry-pick-analyze-codebase-grep`. Extracted ONLY the legitimate `scripts/analyze-codebase.sh` perf change from the closed PR #748 (which had been bundled-bad with workflow + ADR reverts). Single-pass `grep -RIc` + bash array iteration in `check_todo_density` replaces two recursive greps. ~40-50%speedup (180ms to 130ms per original PR body). Shellcheck flagged SC2206 on line 98 (unquoted array expansion) - matches pre-existing pattern on line 133 of the same file; consistent with file convention so no followup amend.
+
+## F15 (PR #751 + #752): CODEOWNERS gate
+
+Branch `ci/codeowners-workflow-adr-gate` + refinement `ci/codeowners-refine-patterns`. Gates `.github/workflows/*.yml`, `.yaml`, `plans/adr-*.md`, `docs/automerge-workflow.md`, and `.jules/` behind `@d-o-hub` review. Initial landing (#751) used a too-coarse `/.github/workflows/` pattern that matched the directory itself rather than files inside; code-reviewer pass triggered #752 with the refined `/*.yml` and `/*.yaml` patterns plus the new `/.jules/` line. Soft enforcement today (branch protection returns 404, no required reviews); can be promoted by adding `Require review from Code Owners` to branch protection when ready.
+
+## Updated Metrics (combined F-series + followup batch)
+
+| Metric | Value |
+|--------|-------|
+| Merged PRs | 11 (#731, #733, #741-#746, #749-#752) |
+| Closed PRs / issues | 5 (#739, #740, #747, #748, ...) |
+| Net self-fix rate | 100% (F7 misdiagnosis recovered by F8 within same session) |
+| New CI safeguards | yaml-validate guard (#749), CODEOWNERS gate (#751-#752) |


### PR DESCRIPTION
Code-reviewer pass on PR #751 found two refinements:

1. Replace bare `/.github/workflows/` (matches directory itself, NOT files inside) with explicit `/*.yml` and `/*.yaml` patterns. All 30 current workflows are .yml; .yaml included for forward-compatibility.

2. Add `/.jules/` to the gate. Jules-task-agent drops sentinel.md/bolt.md into `.jules/` for every task PR (both #747 and #748 included these). Gating `.jules/` blocks the entire Jules-PR class from auto-merging before a human sees the diff.