### PR TITLE
fix(security): pin third-party actions to secure commit SHAs

### DIFF
--- a/.github/workflows/auto-merge-non-deps.yml
+++ b/.github/workflows/auto-merge-non-deps.yml
@@ -153,7 +153,9 @@ jobs:
                     .filter(l => l)
                 )
               ));
-              console.log(`Refusing to auto-merge: ${humanUnresolvedThreads.length} unresolved HUMAN review thread(s).`);
+              console.log(
+                `Refusing to auto-merge: ${humanUnresolvedThreads.length} unresolved HUMAN review thread(s).`
+              );
               for (const t of humanUnresolvedThreads) {
                 console.log(`  - thread ${t.id}`);
               }
@@ -194,7 +196,8 @@ jobs:
               const body = [
                 '## Refusing auto-merge: ' + humanUnresolvedThreads.length + ' unresolved human review thread(s)',
                 '',
-                'This PR carries the `automerge` label, but the workflow refuses to auto-merge because at least one unresolved review thread has a human-authored comment.',
+                'This PR carries the `automerge` label, but the workflow refuses to auto-merge ' +
+                'because at least one unresolved review thread has a human-authored comment.',
                 '',
                 'Human authors with unresolved comments:',
                 ...humanLogins.map(l => '- @' + l),

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,7 +19,7 @@ jobs:
             .github/labeler.yml
           sparse-checkout-cone-mode: false
 
-      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13  # v7.0.0
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d  # v6.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload ShellCheck SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         continue-on-error: true
         with:
           sarif_file: shellcheck-results.sarif
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs
@@ -144,7 +144,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.check_files.outputs.has_codeql_files == 'true'
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         continue-on-error: true
         with:
           languages: javascript,python
@@ -152,12 +152,12 @@ jobs:
 
       - name: Autobuild
         if: steps.check_files.outputs.has_codeql_files == 'true'
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         continue-on-error: true
 
       - name: Perform CodeQL Analysis
         if: steps.check_files.outputs.has_codeql_files == 'true'
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         continue-on-error: true
         with:
           category: "/language:javascript"
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload empty CodeQL SARIF (no supported files found)
         if: steps.check_files.outputs.has_codeql_files == 'false'
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         continue-on-error: true
         with:
           sarif_file: codeql-empty-results.sarif
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload IaC Scan SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.36
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a  # v4.36
         with:
           sarif_file: trivy-config-results.sarif
           category: trivy-config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
 
   # Markdown linting
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.49.0
+    rev: v0.49.1
     hooks:
       - id: markdownlint
         args: ['--config', '.markdownlint-cli2.jsonc']


### PR DESCRIPTION
Align third-party GitHub Actions in .github/workflows/labeler.yml and .github/workflows/security-scan.yml with the secure commit SHA pins enforced by the project security policies to protect the codebase against supply chain vulnerabilities.

---
*PR created automatically by Jules for task [9189178298798334339](https://jules.google.com/task/9189178298798334339) started by @d-o-hub*