### PR TITLE
perf(scripts): eliminate text-matching process forks in bash loop

### DIFF
--- a/scripts/analyze-codebase.sh
+++ b/scripts/analyze-codebase.sh
@@ -152,9 +152,13 @@ check_orphan_cache() {
             esac
         done
         local pat
+        # perf: replace grep -q with native bash match on pre-read content to eliminate process forks
+        local gitignore_content
+        gitignore_content=$'\n'$(< .gitignore)$'\n' 2>/dev/null || gitignore_content=$'\n\n'
         for pat in "${additions[@]:-}"; do
-            if ! grep -qxF "$pat" .gitignore 2>/dev/null; then
+            if [[ "$gitignore_content" != *$'\n'"$pat"$'\n'* ]]; then
                 printf '%s\n' "$pat" >> .gitignore
+                gitignore_content+="$pat"$'\n'
                 log "  added '$pat' to .gitignore"
             fi
         done


### PR DESCRIPTION
Replaced multiple `grep -qxF` process forks in `scripts/analyze-codebase.sh` with native bash string matching by pre-reading the `.gitignore` file. This optimizes the loop execution time by avoiding external process forks.

Impact: Reduces execution time for generating `.gitignore` additions.

---
*PR created automatically by Jules for task [569634117737325759](https://jules.google.com/task/569634117737325759) started by @d-o-hub*