### PR TITLE
fix(security): prevent access to development vaults ide settings and shell configs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,9 @@
+## 2026-08-04 - Prevent Access to Local Environment Vaults, IDE Workspace Settings, and Shell Configs in Path Validation
+
+**Vulnerability:** Gaps in forbidden path denylists left IDE settings (.vscode, .idea), decrypter credentials vaults (.env.vault), and alternative shell environment profiles (.zshenv, .zprofile, .zlogin, .zlogout, .bash_login) vulnerable to potential reading, manipulation, or extraction.
+**Learning:** Hardening directory and file path validations requires securing the entire configuration surface, including localized IDE configs, decrypter vaults holding development secrets, and alternative user-shell profile startup files that are typically read during shell spawning.
+**Prevention:** Continuously maintain a comprehensive, case-insensitive explicit denylist encompassing IDE workspaces (.vscode, .idea), local decrypted credential vaults (.env.vault), and alternative user shell startup configurations (.zshenv, .zprofile, etc.).
+
 ## 2026-07-27 - Hardened Pattern-Based Credential and Cloud Config Blocking in Path Validation
 
 **Vulnerability:** Exact/static matching of forbidden filenames did not block variations of sensitive configurations like custom-named credentials or cloud configuration files (e.g., `credentials.json`, `client_secret.json`, or `kubeconfig`).

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -101,6 +101,14 @@ FORBIDDEN_PATHS = frozenset({
     ".vault-token",
     ".password-store",
     ".erlang.cookie",
+    ".vscode",
+    ".idea",
+    ".env.vault",
+    ".zshenv",
+    ".zprofile",
+    ".zlogin",
+    ".zlogout",
+    ".bash_login",
 })
 
 # Pre-calculate lowercase forbidden paths for efficient case-insensitive matching.

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -73,7 +73,9 @@ def test_validate_safe_path_forbidden(tmp_path):
         ".psql_history", ".sqlite_history", "terraform.tfstate",
         "terraform.tfstate.backup", ".terraform", ".cargo", ".s3cfg",
         ".boto", ".gcloud", ".azure", "_netrc", ".oci", ".sentryclirc",
-        ".vault-token", ".password-store", ".erlang.cookie"
+        ".vault-token", ".password-store", ".erlang.cookie",
+        ".vscode", ".idea", ".env.vault", ".zshenv", ".zprofile",
+        ".zlogin", ".zlogout", ".bash_login"
     ]
     for p in new_forbidden:
         with pytest.raises(PathValidationError):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Gaps in forbidden path denylists left IDE configuration files (.vscode, .idea), decrypter credentials vaults (.env.vault), and alternative shell environments (.zshenv, .zprofile, .zlogin, .zlogout, .bash_login) vulnerable to reading or tampering.
🎯 Impact: Attackers could read sensitive local credentials, local workspace environments, and shell configuration files to escalate privileges or exfiltrate credentials.
🔧 Fix: Added these paths to the core case-insensitive explicit path validation denylist in scripts/lib/paths.py.
✅ Verification: Added comprehensive test cases to tests/test_paths.py validating that any access triggers PathValidationError. All 88 tests pass successfully.

---
*PR created automatically by Jules for task [7687268393497502705](https://jules.google.com/task/7687268393497502705) started by @d-o-hub*