### PR TITLE
fix(security): harden path validation with credential patterns

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,6 +4,11 @@
 **Learning:** Hardening directory and file path validations requires securing the entire configuration surface, including localized IDE configs, decrypter vaults holding development secrets, and alternative user-shell profile startup files that are typically read during shell spawning.
 **Prevention:** Continuously maintain a comprehensive, case-insensitive explicit denylist encompassing IDE workspaces (.vscode, .idea), local decrypted credential vaults (.env.vault), and alternative user shell startup configurations (.zshenv, .zprofile, etc.).
 
+## 2026-07-28 - Comprehensive Pattern-Based Security Path Validation for Credentials and Custom Secrets
+**Vulnerability:** Exact static path matches or limited extension checks in path validation did not block custom secret files or alternative naming variations of credentials (such as `secrets.json`, `credentials.yml`, or arbitrary files prefixed with `secret`/`credential`).
+**Learning:** Relying only on specific suffixes (like `credentials.json`) leaves custom-named credential files or alternate configuration extensions (e.g. `.yml`, `.yaml`, `.vault`) vulnerable to unauthorized reading or mapping. Prefix-based startswith checks for "secret" and "credential" paired with broader suffix rules provide a comprehensive security shield.
+**Prevention:** Apply prefix-based validation to block files beginning with generic key-terms ("secret", "credential") alongside explicit extension suffixes (`.secrets`, `.credentials`, `.vault`) in path validation checks, ensuring that all such configurations are systematically rejected.
+
 ## 2026-07-27 - Hardened Pattern-Based Credential and Cloud Config Blocking in Path Validation
 
 **Vulnerability:** Exact/static matching of forbidden filenames did not block variations of sensitive configurations like custom-named credentials or cloud configuration files (e.g., `credentials.json`, `client_secret.json`, or `kubeconfig`).

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -158,13 +158,15 @@ def validate_safe_path(
             # Note: .key is intentionally broad to catch private keys despite potential false positives.
             # SSH private key prefixes cover custom-named keys and newer types (e.g. id_ed25519_sk, id_rsa_backup).
             if (
-                part_lower.startswith((".env", "client_secret", "kubeconfig")) or
+                part_lower.startswith((".env", "client_secret", "kubeconfig", "secret", "credential")) or
                 part_lower.endswith((
                     ".pem", ".key", ".pfx", ".tfstate", ".crt", ".cer",
                     ".p12", ".pkcs8", ".pk8", ".der", ".keystore", ".jks",
                     ".dockercfg", ".publishsettings", ".gpg", ".pgp", ".asc",
                     ".p8", ".pkcs12", ".passwd", ".pwd", ".htpasswd", "_history",
-                    "credentials.json", "client_secret.json", "kubeconfig"
+                    "credentials.json", "client_secret.json", "kubeconfig",
+                    ".secrets", ".credentials", ".vault", "secrets.json",
+                    "secrets.yml", "secrets.yaml", "credentials.yml", "credentials.yaml"
                 )) or
                 (
                     part_lower.startswith(("identity", "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "id_xmss")) and

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -100,7 +100,9 @@ def test_validate_safe_path_patterns(tmp_path):
         "secret.gpg", "secret.pgp", "secret.asc", "key.p8", "key.pkcs12",
         "secret.passwd", "secret.pwd", "secret.htpasswd", "app_history",
         "client_secret.json", "credentials.json", "kubeconfig", "my_kubeconfig",
-        "client_secret_xyz.json"
+        "client_secret_xyz.json", "secrets.json", "secrets.yml", "secrets.yaml",
+        "credentials.yml", "credentials.yaml", "production.secrets", "api.credentials",
+        "my.vault"
     ]
     for p in sensitive_extensions:
         with pytest.raises(PathValidationError):
@@ -108,7 +110,8 @@ def test_validate_safe_path_patterns(tmp_path):
 
     # Prefix matches
     prefix_patterns = [
-        "client_secret", "client_secret_local", "kubeconfig", "kubeconfig_prod"
+        "client_secret", "client_secret_local", "kubeconfig", "kubeconfig_prod",
+        "secret_keys.json", "secrets_config", "credential_helper", "credentials_file"
     ]
     for p in prefix_patterns:
         with pytest.raises(PathValidationError):


### PR DESCRIPTION
### Description
- **Vulnerability:** Exact static path matches or limited extension checks in path validation did not block custom secret files or alternative naming variations of credentials (such as `secrets.json`, `credentials.yml`, or arbitrary files prefixed with `secret`/`credential`).
- **Impact:** Potential unauthorized reading or mapping of custom-named sensitive credentials or cloud configuration files.
- **Fix:** Added generic prefix-based startswith checks for "secret" and "credential" in `validate_safe_path`, and introduced broader file extension and suffix checks for configurations including `.secrets`, `.credentials`, `.vault`, `secrets.json`, `secrets.yml`, `secrets.yaml`, and `credentials.yaml`.
- **Alignments:** Updated the `turso-db` version check in `tests/turso-db.bats` from `0.7.0` to `0.7.2` to resolve the version mismatch with the actual skill metadata.
- **Verification:** Added comprehensive tests for prefix/suffix pattern validation to `tests/test_paths.py`. All pytest and bats tests passed successfully.

---
*PR created automatically by Jules for task [14313738993357405238](https://jules.google.com/task/14313738993357405238) started by @d-o-hub*