### PR TITLE
fix(security): block database credentials and legacy shell profiles in path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,9 @@
+## 2026-08-11 - Block Database Credentials and Alternative Shell/REPL Configurations in Path Validation
+
+**Vulnerability:** Gaps in forbidden path validation permitted potential reading, enumeration, or exfiltration of database credential files (`.pgpass`, `.my.cnf`, `.pg_service.conf`), alternative REPL history files (`.irb_history`, `.pry_history`), and legacy shell startup configurations (`.tcshrc`, `.cshrc`, `.login`, `.logout`).
+**Learning:** Reconstructing robust boundary controls requires safeguarding all credential stores and environment definitions, including database-specific configuration folders, REPL/interactive logs, and legacy shells that agents could leverage or inspect.
+**Prevention:** Continuously maintain a case-insensitive explicit denylist enclosing database client passwords (`.pgpass`), connection credentials (`.my.cnf`, `.pg_service.conf`), interactive console histories (`.irb_history`, `.pry_history`), and legacy user shell profiles (`.tcshrc`, `.cshrc`, `.login`, `.logout`).
+
 ## 2026-08-04 - Prevent Access to Local Environment Vaults, IDE Workspace Settings, and Shell Configs in Path Validation
 
 **Vulnerability:** Gaps in forbidden path denylists left IDE settings (.vscode, .idea), decrypter credentials vaults (.env.vault), and alternative shell environment profiles (.zshenv, .zprofile, .zlogin, .zlogout, .bash_login) vulnerable to potential reading, manipulation, or extraction.

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -109,6 +109,15 @@ FORBIDDEN_PATHS = frozenset({
     ".zlogin",
     ".zlogout",
     ".bash_login",
+    ".pgpass",
+    ".my.cnf",
+    ".irb_history",
+    ".pry_history",
+    ".pg_service.conf",
+    ".tcshrc",
+    ".cshrc",
+    ".login",
+    ".logout",
 })
 
 # Pre-calculate lowercase forbidden paths for efficient case-insensitive matching.

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -75,7 +75,9 @@ def test_validate_safe_path_forbidden(tmp_path):
         ".boto", ".gcloud", ".azure", "_netrc", ".oci", ".sentryclirc",
         ".vault-token", ".password-store", ".erlang.cookie",
         ".vscode", ".idea", ".env.vault", ".zshenv", ".zprofile",
-        ".zlogin", ".zlogout", ".bash_login"
+        ".zlogin", ".zlogout", ".bash_login", ".pgpass", ".my.cnf",
+        ".irb_history", ".pry_history", ".pg_service.conf",
+        ".tcshrc", ".cshrc", ".login", ".logout"
     ]
     for p in new_forbidden:
         with pytest.raises(PathValidationError):


### PR DESCRIPTION
🛡️ Sentinel: Block Database Credentials and Alternative Shell/REPL Configurations in Path Validation

🚨 Severity: HIGH/MEDIUM
💡 Vulnerability: Gaps in forbidden path validation permitted potential reading, enumeration, or exfiltration of database credential files (`.pgpass`, `.my.cnf`, `.pg_service.conf`), alternative REPL history files (`.irb_history`, `.pry_history`), and legacy shell startup configurations (`.tcshrc`, `.cshrc`, `.login`, `.logout`).
🎯 Impact: An attacker or untrusted agent could exploit these gaps to extract database login details, parse historical interactive CLI sessions containing sensitive inputs, or modify/intercept custom environment configuration scripts.
🔧 Fix: Added these highly sensitive database configurations, logs, and alternative shell profiles directly to the case-insensitive explicit denylist (`FORBIDDEN_PATHS`) inside `scripts/lib/paths.py`.
✅ Verification: Added comprehensive unit tests inside `tests/test_paths.py` confirming each of the newly forbidden paths correctly raises `PathValidationError`. Run the entire suite with `python3 -m pytest tests/` and project checks via `bash scripts/quality_gate.sh`, both passing flawlessly.

---
*PR created automatically by Jules for task [10018131720833718781](https://jules.google.com/task/10018131720833718781) started by @d-o-hub*