### PR TITLE
fix(security): block generalized ssh private keys in path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,9 @@
+## 2026-08-08 - Block Generalized SSH Private Keys in Path Validation Pattern Matches
+
+**Vulnerability:** Prior to this hardening, path validation logic only checked a static list of explicit algorithm-prefixed SSH private key names (e.g., `id_rsa`, `id_ed25519`). This permitted access to dynamically named, backed-up, or alternatively alg-named private keys (such as `id_custom_key` or `id_temp`) starting with the standard SSH `id_` prefix if they were not explicitly covered.
+**Learning:** Restricting pattern matches to explicit algorithms introduces omissions as SSH key naming schemes and algorithms can be dynamically configured. A generic startswith check for the standard key-prefix `id_` coupled with public key exemptions provides complete and robust security boundary protection for all variations of SSH private keys.
+**Prevention:** Always employ a generalized pattern-based startswith filter for standard key prefixes like `id_` while excluding public keys with `.pub` suffix checks, rather than keeping an exhaustive list of exact key algorithms.
+
 ## 2026-08-04 - Prevent Access to Local Environment Vaults, IDE Workspace Settings, and Shell Configs in Path Validation
 
 **Vulnerability:** Gaps in forbidden path denylists left IDE settings (.vscode, .idea), decrypter credentials vaults (.env.vault), and alternative shell environment profiles (.zshenv, .zprofile, .zlogin, .zlogout, .bash_login) vulnerable to potential reading, manipulation, or extraction.
@@ -99,7 +105,7 @@
 
 **Vulnerability:** Exact static matching in `FORBIDDEN_PATHS` did not protect cloud configuration folders (like `.cargo`, `.s3cfg`, `.boto`, `.gcloud`, `.azure`) if referenced directly, and `validate_safe_path`'s suffix check lacked coverage for keyrings/gpg, password files, and custom history patterns.
 **Learning:** Hardcoded denylists and static file sets are easily bypassed by alternative tools, configurations, or naming structures. Comprehensive protection must pair expanded explicit lists with robust, pattern-based validation checks covering extensions and keywords for password/keyring/history resources.
-**Prevention:** Continuously enrich path validation filters with standard cloud and package manager directories (`.cargo`, `.azure`, etc.), while ensuring pattern-based suffix matches reject cryptographic keys/keyrings (`.gpg`, `.pgp`, `.asc`, `.p8`, `.pkcs12`), credential stores (`.passwd`, `.pwd`, `.htpasswd`), and history files (`_history`).
+**Prevention:** Continuously enrich path validation filters with standard cloud and package manager directories (`.azure`, `.cargo`, etc.), while ensuring pattern-based suffix matches reject cryptographic keys/keyrings (`.gpg`, `.pgp`, `.asc`, `.p8`, `.pkcs12`), credential stores (`.passwd`, `.pwd`, `.htpasswd`), and history files (`_history`).
 
 ## 2026-07-26 - Enforcing Forbidden Path Validation in Skill Evaluation File Validation
 **Vulnerability:** The file validation check inside `run_file_validation` failed to enforce `check_forbidden=True` on path-validation logic, leaving a potential vector for verifying, mapping, or exposing the existence of sensitive forbidden files/folders such as `.env`, `.git`, or custom credentials within skill paths.

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -169,7 +169,7 @@ def validate_safe_path(
                     "secrets.yml", "secrets.yaml", "credentials.yml", "credentials.yaml"
                 )) or
                 (
-                    part_lower.startswith(("identity", "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519", "id_xmss")) and
+                    part_lower.startswith(("identity", "id_")) and
                     not part_lower.endswith(".pub")
                 )
             ):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -191,13 +191,19 @@ def test_validate_safe_path_ssh_keys(tmp_path):
     base.mkdir()
 
     # Dynamic private keys (e.g. custom names)
-    private_keys = ["id_rsa_personal", "id_ed25519_github", "id_dsa_old", "id_ecdsa_corp", "id_xmss_test"]
+    private_keys = [
+        "id_rsa_personal", "id_ed25519_github", "id_dsa_old", "id_ecdsa_corp", "id_xmss_test",
+        "id_custom_key", "id_temp", "id_backup", "id_web"
+    ]
     for pk in private_keys:
         with pytest.raises(PathValidationError):
             validate_safe_path(pk, base, "test", check_forbidden=True)
 
     # Public keys should be allowed
-    public_keys = ["id_rsa.pub", "id_ed25519_github.pub", "id_dsa_old.pub", "id_ecdsa_corp.pub", "id_xmss_test.pub"]
+    public_keys = [
+        "id_rsa.pub", "id_ed25519_github.pub", "id_dsa_old.pub", "id_ecdsa_corp.pub", "id_xmss_test.pub",
+        "id_custom_key.pub", "id_temp.pub", "id_backup.pub", "id_web.pub"
+    ]
     for pub in public_keys:
         res = validate_safe_path(pub, base, "test", check_forbidden=True)
         expected = (base / pub).resolve()


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

🚨 Severity: MEDIUM
💡 Vulnerability: Prior to this hardening, path validation logic only checked a static list of explicit algorithm-prefixed SSH private key names (e.g., id_rsa, id_ed25519). This permitted access to dynamically named, backed-up, or alternatively alg-named private keys starting with the standard SSH id_ prefix.
🎯 Impact: Dynamic or backed-up SSH private keys could potentially be accessed or traversed if the application parsed untrusted paths.
🔧 Fix: Generalize the SSH private key detection in validate_safe_path to block any path component starting with the standard 'id_' prefix unless it ends with the '.pub' extension. This provides robust and comprehensive coverage for all variations of SSH private keys.
✅ Verification: Added comprehensive unit test coverage in tests/test_paths.py validating that dynamically named private keys (e.g., id_custom_key, id_temp, id_backup) are rejected, while public keys are correctly permitted.

---
*PR created automatically by Jules for task [10295890909666060550](https://jules.google.com/task/10295890909666060550) started by @d-o-hub*