### PR TITLE
fix(security): explicitly block legacy shell profiles and database credentials in path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,9 @@
+## 2026-08-10 - Explicit Path Validation for Local Database and Legacy Shell Configurations
+
+**Vulnerability:** Gaps in forbidden path validations left database credentials/configs (.pgpass, .my.cnf, .pg_service.conf), interactive REPL histories (.irb_history, .pry_history), and legacy shell profiles (.tcshrc, .cshrc, .login, .logout) vulnerable to potential reading, manipulation, or extraction.
+**Learning:** Security boundaries must cover all local configurations and history stores, particularly legacy shell configurations and interactive environment histories that do not fit standard regexes or newer profile matches.
+**Prevention:** Maintain a comprehensive and hardened forbidden paths denylist, explicitly enumerating database credentials and legacy REPL/shell files, backed by test coverage verifying each path.
+
 ## 2026-08-04 - Prevent Access to Local Environment Vaults, IDE Workspace Settings, and Shell Configs in Path Validation
 
 **Vulnerability:** Gaps in forbidden path denylists left IDE settings (.vscode, .idea), decrypter credentials vaults (.env.vault), and alternative shell environment profiles (.zshenv, .zprofile, .zlogin, .zlogout, .bash_login) vulnerable to potential reading, manipulation, or extraction.

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -109,6 +109,15 @@ FORBIDDEN_PATHS = frozenset({
     ".zlogin",
     ".zlogout",
     ".bash_login",
+    ".irb_history",
+    ".pry_history",
+    ".tcshrc",
+    ".cshrc",
+    ".login",
+    ".logout",
+    ".pgpass",
+    ".my.cnf",
+    ".pg_service.conf",
 })
 
 # Pre-calculate lowercase forbidden paths for efficient case-insensitive matching.

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -75,7 +75,9 @@ def test_validate_safe_path_forbidden(tmp_path):
         ".boto", ".gcloud", ".azure", "_netrc", ".oci", ".sentryclirc",
         ".vault-token", ".password-store", ".erlang.cookie",
         ".vscode", ".idea", ".env.vault", ".zshenv", ".zprofile",
-        ".zlogin", ".zlogout", ".bash_login"
+        ".zlogin", ".zlogout", ".bash_login", ".irb_history", ".pry_history",
+        ".tcshrc", ".cshrc", ".login", ".logout", ".pgpass", ".my.cnf",
+        ".pg_service.conf"
     ]
     for p in new_forbidden:
         with pytest.raises(PathValidationError):


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Lack of explicit blocking of database credentials (.pgpass, .my.cnf, .pg_service.conf), interactive REPL histories (.irb_history, .pry_history), and legacy shell profiles (.tcshrc, .cshrc, .login, .logout) left these sensitive files vulnerable to potential reading or unauthorized access by automated agents.
🎯 Impact: Attackers or misconfigured processes could exploit this gap to access local database configurations/credentials and interactive history files, which often contain sensitive environment details, command parameters, or decrypted credentials.
🔧 Fix: Enriched the static FORBIDDEN_PATHS denylist inside scripts/lib/paths.py to explicitly incorporate these file types, ensuring case-insensitive rejection under all path-validation routines.
✅ Verification: Added tests verifying the correct validation failure and PathValidationError raise for each newly added path to tests/test_paths.py, and verified that the entire test suite runs and passes cleanly.

---
*PR created automatically by Jules for task [14832249681762527536](https://jules.google.com/task/14832249681762527536) started by @d-o-hub*