### PR TITLE
fix(security): explicitly block legacy shell startup configs, db credentials, and REPL histories in path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,9 @@
+## 2026-08-11 - Enforce Explicit Forbidden Path Validation for Database Credentials, Legacy Shells, and REPL Histories
+
+**Vulnerability:** Database credential files (`.pgpass`, `.my.cnf`, `.pg_service.conf`), alternative legacy shell configurations (`.tcshrc`, `.cshrc`, `.login`, `.logout`), and interactive REPL histories (`.irb_history`, `.pry_history`) were omitted from the explicit `FORBIDDEN_PATHS` denylist in path validation, creating potential information disclosure and configuration reading gaps.
+**Learning:** Security validations must explicitly cover database credentials and alternative REPL/interactive shells to ensure complete isolation and prevent exfiltration of database connections or shell context history.
+**Prevention:** Maintain a comprehensive, case-insensitive denylist that explicitly covers database credential files, alternative shell profiles, and interactive REPL histories, paired with automated unit tests to prevent regression.
+
 ## 2026-08-04 - Prevent Access to Local Environment Vaults, IDE Workspace Settings, and Shell Configs in Path Validation
 
 **Vulnerability:** Gaps in forbidden path denylists left IDE settings (.vscode, .idea), decrypter credentials vaults (.env.vault), and alternative shell environment profiles (.zshenv, .zprofile, .zlogin, .zlogout, .bash_login) vulnerable to potential reading, manipulation, or extraction.

--- a/scripts/lib/paths.py
+++ b/scripts/lib/paths.py
@@ -109,6 +109,15 @@ FORBIDDEN_PATHS = frozenset({
     ".zlogin",
     ".zlogout",
     ".bash_login",
+    ".tcshrc",
+    ".cshrc",
+    ".login",
+    ".logout",
+    ".pgpass",
+    ".my.cnf",
+    ".pg_service.conf",
+    ".irb_history",
+    ".pry_history",
 })
 
 # Pre-calculate lowercase forbidden paths for efficient case-insensitive matching.

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -75,7 +75,9 @@ def test_validate_safe_path_forbidden(tmp_path):
         ".boto", ".gcloud", ".azure", "_netrc", ".oci", ".sentryclirc",
         ".vault-token", ".password-store", ".erlang.cookie",
         ".vscode", ".idea", ".env.vault", ".zshenv", ".zprofile",
-        ".zlogin", ".zlogout", ".bash_login"
+        ".zlogin", ".zlogout", ".bash_login", ".tcshrc", ".cshrc",
+        ".login", ".logout", ".pgpass", ".my.cnf", ".pg_service.conf",
+        ".irb_history", ".pry_history"
     ]
     for p in new_forbidden:
         with pytest.raises(PathValidationError):


### PR DESCRIPTION
This security enhancement explicitly hardens `scripts/lib/paths.py` against unauthorized access to legacy shell startup configurations, database credentials, and interactive REPL histories.

### Vulnerability
Database credential files (`.pgpass`, `.my.cnf`, `.pg_service.conf`), alternative legacy shell configurations (`.tcshrc`, `.cshrc`, `.login`, `.logout`), and interactive REPL histories (`.irb_history`, `.pry_history`) were omitted from the explicit `FORBIDDEN_PATHS` denylist in path validation, creating potential information disclosure and configuration reading gaps.

### Impact
If left unblocked, these files could potentially be read, listed, or extracted by automated agents under permissive path validations.

### Fix
- Added `.tcshrc`, `.cshrc`, `.login`, `.logout`, `.pgpass`, `.my.cnf`, `.pg_service.conf`, `.irb_history`, and `.pry_history` to `FORBIDDEN_PATHS` in `scripts/lib/paths.py`.
- Updated unit tests in `tests/test_paths.py` to assert that they correctly raise `PathValidationError` when `check_forbidden=True`.

### Verification
- Run `pytest tests/` to confirm all 88 unit tests pass.
- Run `bash scripts/quality_gate.sh` to confirm quality gate compliance.

---
*PR created automatically by Jules for task [13125149419427544691](https://jules.google.com/task/13125149419427544691) started by @d-o-hub*