### PR TITLE
fix(ci): disable footer-max-line-length for squash merge bodies

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -18,7 +18,11 @@ module.exports = {
     // naturally exceed 100 chars. Enforced at PR level (1000 chars) instead.
     'body-max-line-length': [0],
     'footer-max-length': [2, 'always', 1000],
-    'footer-max-line-length': [2, 'always', 100],
+    // footer-max-line-length disabled — GitHub squash merges append the PR body
+    // (free-form markdown with >100-char lines) as the commit footer, which made
+    // the 2026-08-07 Commit Lint run on main fail (8d673e1). Same rationale as
+    // body-max-line-length above: line length is enforced at PR level instead.
+    'footer-max-line-length': [0],
     // subject-case disabled: identifiers like LESSON-017, SKILL.md are valid
     'subject-case': [0],
   },

--- a/tests/test-commitlint-rules.sh
+++ b/tests/test-commitlint-rules.sh
@@ -50,7 +50,11 @@ check_consistency "'body-max-length'" "\\[0\\]" "Body max length (disabled)"
 # The AGENTS.md "Wrap at 100 chars per line" is a recommendation, not enforced.
 check_consistency "'body-max-line-length'" "\\[0\\]" "Body max line length (disabled)"
 check_consistency "'footer-max-length'" "1000" "Footer max length"
-check_consistency "'footer-max-line-length'" "100" "Footer max line length"
+# footer-max-line-length is intentionally disabled ([0]) because GitHub
+# squash merges append the free-form PR body as the commit footer; markdown
+# lines >100 chars are normal (2026-08-07 main Commit Lint failure on 8d673e1).
+# Line length is enforced at PR level instead, same as body-max-line-length.
+check_consistency "'footer-max-line-length'" "\\[0\\]" "Footer max line length (disabled)"
 # subject-case is intentionally disabled ([0]) because identifiers like
 # LESSON-017, SKILL.md, and technical references are valid commit subjects
 check_consistency "'subject-case'" "\\[0\\]" "Subject case (disabled)"

--- a/tests/test-commitlint-rules.sh
+++ b/tests/test-commitlint-rules.sh
@@ -39,25 +39,30 @@ check_consistency() {
     fi
 }
 
+
+# Literal used for commitlint "disabled" rules ([0]); centralized to keep
+# SonarCloud S1192 (duplicate string literal) below the threshold.
+DISABLED_SET="\\[0\\]"
+
 printf "Checking consistency with AGENTS.md...\n"
 check_consistency "'header-max-length'" "150" "Header max length"
 # body-max-length is intentionally disabled ([0]) because squash merges
 # produce long commit bodies from PR descriptions. Enforced at PR level
 # via lint-pr-title workflow body-length warning step.
-check_consistency "'body-max-length'" "\\[0\\]" "Body max length (disabled)"
+check_consistency "'body-max-length'" "$DISABLED_SET" "Body max length (disabled)"
 # body-max-line-length is intentionally disabled ([0]) because squash merge
 # bodies from gh pr merge --squash naturally exceed 100 characters per line.
 # The AGENTS.md "Wrap at 100 chars per line" is a recommendation, not enforced.
-check_consistency "'body-max-line-length'" "\\[0\\]" "Body max line length (disabled)"
+check_consistency "'body-max-line-length'" "$DISABLED_SET" "Body max line length (disabled)"
 check_consistency "'footer-max-length'" "1000" "Footer max length"
 # footer-max-line-length is intentionally disabled ([0]) because GitHub
 # squash merges append the free-form PR body as the commit footer; markdown
 # lines >100 chars are normal (2026-08-07 main Commit Lint failure on 8d673e1).
 # Line length is enforced at PR level instead, same as body-max-line-length.
-check_consistency "'footer-max-line-length'" "\\[0\\]" "Footer max line length (disabled)"
+check_consistency "'footer-max-line-length'" "$DISABLED_SET" "Footer max line length (disabled)"
 # subject-case is intentionally disabled ([0]) because identifiers like
 # LESSON-017, SKILL.md, and technical references are valid commit subjects
-check_consistency "'subject-case'" "\\[0\\]" "Subject case (disabled)"
+check_consistency "'subject-case'" "$DISABLED_SET" "Subject case (disabled)"
 
 printf "Checking dependabot commitlint exemption...\n"
 if grep -q "ignores" "$CONFIG_FILE"; then

--- a/tests/test-workflow-logic.bats
+++ b/tests/test-workflow-logic.bats
@@ -5,8 +5,10 @@
     grep -q "cancel-in-progress: true" .github/workflows/ci.yml
 }
 
-@test "workflow includes skip ci in status commit" {
-    grep -q 'commit -m "ci: update ci status artifacts \[skip ci\]"' .github/workflows/ci.yml
+@test "workflow delegates CI status persistence to persist script" {
+    grep -q "persist-ci-status.sh" .github/workflows/ci.yml
+    test -x scripts/persist-ci-status.sh
+    grep -q 'ci: update ci status artifacts \[skip ci\]' scripts/persist-ci-status.sh
 }
 
 @test "workflow persists CI data only on main" {


### PR DESCRIPTION
Root-cause fix for the 2026-08-07 **Commit Lint failure on main** (commit `8d673e1`, run `31176723566`):

```
commitlint: ✖ footer's lines must not be longer than 100 characters [footer-max-line-length]
```

GitHub squash merges append the free-form PR body as the commit footer; markdown lines >100 chars are normal, so enforcing `footer-max-line-length: 100` makes Commit Lint red on valid merges. This mirrors the existing `body-max-line-length: [0]` disable and keeps `footer-max-length: 1000` for the total. The quality-gate consistency test (`tests/test-commitlint-rules.sh`) is updated in lock-step.

Verified: `commitlint` passes a message with a >100-char footer line (previously failed), and `./scripts/quality_gate.sh` passes.
