### PR TITLE
fix(ci): register unit pytest marker in do-web-doc-resolver

### DIFF
--- a/.agents/skills/do-web-doc-resolver/pyproject.toml
+++ b/.agents/skills/do-web-doc-resolver/pyproject.toml
@@ -154,6 +154,7 @@ python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
 markers = [
+    "unit: marks unit tests that run fast without external services",
     "live: marks tests as live integration tests requiring real API keys (deselect with '-m not live')",
     "integration: marks integration tests that may require external services or built binaries",
     "benchmark: enables pytest-benchmark style tests without plugin",


### PR DESCRIPTION
Clears the recurring CI warning in the **Run tests (Python skills)** job:

```
PytestUnknownMarkWarning: Unknown pytest.mark.unit - is this a typo?
  .agents/skills/do-web-doc-resolver/tests/test_cache_helpers.py:14
```

`test_cache_helpers.py` uses `@pytest.mark.unit` but the skill's `[tool.pytest.ini_options] markers` never registered it. Adding the `unit` marker removes the warning (verified locally: `pytest tests/test_cache_helpers.py -m 'not live'` → 4 passed, 0 warnings).
