### PR TITLE
fix(ci): persist ci status via automerge PR when main push is blocked

### DIFF
--- a/.github/ci-status/ci-status.json
+++ b/.github/ci-status/ci-status.json
@@ -1,6 +1,6 @@
 {
   "status": "passing",
-  "last_run": "2026-06-18T15:45:10.817605Z",
+  "last_run": "2026-08-11T19:00:51.312456Z",
   "failing_jobs": [],
-  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/27771228314"
+  "workflow_url": "https://github.com/d-o-hub/github-template-ai-agents/actions/runs/31524648372"
 }

--- a/.github/ci-status/ci-summary.md
+++ b/.github/ci-status/ci-summary.md
@@ -2,8 +2,8 @@
 
 Latest CI status: **passing**
 
-- **Last Run:** 2026-06-18T15:45:10.817605Z
-- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/27771228314](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/27771228314)
+- **Last Run:** 2026-08-11T19:00:51.312456Z
+- **Workflow URL:** [https://github.com/d-o-hub/github-template-ai-agents/actions/runs/31524648372](https://github.com/d-o-hub/github-template-ai-agents/actions/runs/31524648372)
 
 ## Job Status
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
     if: always()
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -314,17 +315,9 @@ jobs:
 
       - name: Persist CI data to main
         if: github.ref == 'refs/heads/main' && always()
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/ci-status/
-          if git diff --staged --quiet; then
-            printf "No changes to CI status\n"
-            exit 0
-          fi
-          git commit -m "ci: update ci status artifacts [skip ci]"
-          git push origin main
-        continue-on-error: true
+        run: ./scripts/persist-ci-status.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Check all required jobs passed
         run: |

--- a/scripts/persist-ci-status.sh
+++ b/scripts/persist-ci-status.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# persist-ci-status.sh - Commit .github/ci-status/ artifacts and sync them to the default branch.
+#
+# Tries a direct push to `main` first. Because the repo's branch ruleset requires a PR
+# for `main` (the GITHUB_TOKEN cannot bypass it), direct pushes are rejected — historically
+# this was masked by `continue-on-error: true`, leaving ci-status.json stale for weeks
+# (e.g. last_run 2026-06-18 while main kept merging). This script falls back to pushing to
+# a `ci/ci-status-update` branch and opening (or re-pointing) an `automerge`-labeled PR so
+# the template's auto-merge-non-deps workflow merges it once required checks pass.
+set -euo pipefail
+
+BRANCH="${CI_STATUS_SYNC_BRANCH:-ci/ci-status-update}"
+LABEL="${CI_STATUS_SYNC_LABEL:-automerge}"
+TITLE="${CI_STATUS_TITLE:-ci: update ci status artifacts [skip ci]}"
+BODY="${CI_STATUS_BODY:-Automated CI status artifacts update. Merged by the template automerge workflow.}"
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+git add .github/ci-status/
+if git diff --staged --quiet; then
+  printf 'No changes to CI status artifacts; nothing to persist.\n'
+  exit 0
+fi
+
+git commit -m "$TITLE"
+
+if git push origin HEAD:main; then
+  printf 'Pushed CI status artifacts directly to main.\n'
+  exit 0
+fi
+
+printf 'Direct push to main rejected by branch ruleset; opening an automerge PR instead.\n' >&2
+
+git push --force origin "HEAD:$BRANCH" 2>&1 | sed 's/^/  /'
+
+pr_number="$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+if [[ -n "$pr_number" ]]; then
+  gh pr edit "$pr_number" --title "$TITLE" --body "$BODY" --add-label "$LABEL" >/dev/null 2>&1 || true
+  printf 'Updated existing CI status PR #%s.\n' "$pr_number"
+  exit 0
+fi
+
+pr_url="$(gh pr create --base main --head "$BRANCH" --title "$TITLE" --body "$BODY" --label "$LABEL" 2>/dev/null || true)"
+if [[ -n "$pr_url" ]]; then
+  pr_number="$(basename "$pr_url")"
+  printf 'Created CI status PR #%s.\n' "$pr_number"
+else
+  printf 'WARNING: could not create/update CI status PR for branch %s.\n' "$BRANCH" >&2
+  exit 1
+fi


### PR DESCRIPTION
**Root-cause fix for stale `.github/ci-status/ci-status.json`** (was frozen at `last_run: 2026-06-18` for ~7 weeks while main kept merging).

The `ci-success` job's `Persist CI data to main` step did a bare `git push origin main`, which the `Main Branch Protection` ruleset rejects (`remote: error: GH013: Repository rule violations found for refs/heads/main`), and `continue-on-error: true` silently swallowed it — so CI status artifacts have been stale since 2026-06-18 and the AGENTS.md CI-status gating reads outdated data.

**Changes:**
- New `scripts/persist-ci-status.sh`: commits `.github/ci-status/`, tries a direct push to `main`, and if the ruleset rejects it, force-pushes to a `ci/ci-status-update` branch and opens/updates an `automerge`-labeled PR that the existing `auto-merge-non-deps` workflow merges once required checks pass. `continue-on-error` is removed so a failure surfaces instead of being hidden.
- `ci.yml`: grant the `ci-success` job `pull-requests: write` and delegate to the new script.
- Refresh `ci-status.json` / `ci-summary.md` to the current passing state so gating reads fresh data immediately.

Validated: script bash-syntax + `shellcheck -S error` clean; commit+push path exercised in a local sandbox; local quality gate passes.
