### PR TITLE
fix(security): align codeql action sha with pinned versions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload ShellCheck SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         continue-on-error: true
         with:
           sarif_file: shellcheck-results.sarif
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs
@@ -145,7 +145,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.check_files.outputs.has_codeql_files == 'true'
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         continue-on-error: true
         with:
           languages: javascript,python
@@ -153,12 +153,12 @@ jobs:
 
       - name: Autobuild
         if: steps.check_files.outputs.has_codeql_files == 'true'
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         continue-on-error: true
 
       - name: Perform CodeQL Analysis
         if: steps.check_files.outputs.has_codeql_files == 'true'
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         continue-on-error: true
         with:
           category: "/language:javascript"
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload empty CodeQL SARIF (no supported files found)
         if: steps.check_files.outputs.has_codeql_files == 'false'
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         continue-on-error: true
         with:
           sarif_file: codeql-empty-results.sarif
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload IaC Scan SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3   # v4.36
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.36
         with:
           sarif_file: trivy-config-results.sarif
           category: trivy-config


### PR DESCRIPTION
Align github/codeql-action references in security-scan workflow with the expected pinned SHA.
This fixes test failures and ensures consistent, pinned actions to prevent supply chain risks.

Vulnerability: Outdated or mismatched action SHAs can break tests and introduce supply chain risks.
Impact: Ensures all CodeQL actions are securely pinned to the same verified v4.36 release SHA.
Fix: Updated 7 references in `.github/workflows/security-scan.yml` to use `f205ea1c3313d32999d8d6a48b4f6530d4437b38`.
Verification: Verified with pytest which now passes successfully.

---
*PR created automatically by Jules for task [1598976590147330917](https://jules.google.com/task/1598976590147330917) started by @d-o-hub*